### PR TITLE
Resolve issues with API changes from Wyze (2024-02-01)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wyze-api",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "An unoficial API wrapper for Wyze products.",
   "homepage": "https://github.com/jfarmer08/wyze-api",
   "main": "./src/index.js",

--- a/src/constants.js
+++ b/src/constants.js
@@ -14,8 +14,7 @@ module.exports = Object.freeze({
   sc: "wyze_developer_api",
   sv: "wyze_developer_api",
   authApiKey: "WMXHYf79Nr5gIlt3r0r7p9Tcw5bvs6BB4U8O8nGJ",
-  userAgent:
-    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1 Safari/605.1.15",
+  userAgent: "unofficial-wyze-api/1.0",
 
   //URLs
   authBaseUrl: "https://auth-prod.api.wyze.com",

--- a/src/index.js
+++ b/src/index.js
@@ -128,7 +128,7 @@ module.exports = class WyzeAPI {
       throw e
     }
     if (result.data.msg) {
-      if (result.data.msg == "DeviceIsOffline") { return result } else
+      if (result.data.msg == "DeviceIsOffline" || result.data.msg != "SUCCESS") { return result } else
         throw new Error(result.data.msg)
     } else { return result }
   }

--- a/src/index.js
+++ b/src/index.js
@@ -128,7 +128,7 @@ module.exports = class WyzeAPI {
       throw e
     }
     if (result.data.msg) {
-      if (result.data.msg == "DeviceIsOffline" || result.data.msg != "SUCCESS") { return result } else
+      if (result.data.msg == "DeviceIsOffline" || result.data.msg == "SUCCESS") { return result } else
         throw new Error(result.data.msg)
     } else { return result }
   }


### PR DESCRIPTION
Attempt to resolve https://github.com/jfarmer08/wyze-api/issues/2

- Update check in `_performRequest` to handle `SUCCESS` as valid `msg`, this appears to be a change in the API.
- Update user-agent to be more general, rather than a specific user agent from a browser.

Verification of user agent functionality:

```
[08:21:03] ~/wyze-homebridge λ curl --write-out '%{http_code}' -SsL --output /dev/null -XPOST -d "{\"email\":\"$EMAIL\",\"password\":\"$PASSWORD\"}" --header "Content-Type: application/json" --header "apikey: $API_KEY" --header "keyid: $KEY_ID" --header "User-Agent: unofficial-wyze-api/1.0" https://auth-prod.api.wyze.com/api/user/login
200%
```