### PR TITLE
Draft: Initial attempt at naive debounce for login api

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,8 @@
+USERNAME=username
+PASSWORD=password
+KEY_ID=keyId
+API_KEY=apiKey
+PERSIST_PATH=./scratch
+LOG_LEVEL=debug
+API_LOG_ENABLED=true
+LOCAL_DEV=true

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules/*
 example/node_modules/*
 example/scratch/*
+.env

--- a/example/index.js
+++ b/example/index.js
@@ -36,5 +36,5 @@ async function deviceListCheck() {
 
 (async () => {
   // await deviceListCheck();
-  await loginCheck();
+  // await loginCheck();
 })()

--- a/example/index.js
+++ b/example/index.js
@@ -36,5 +36,5 @@ async function deviceListCheck() {
 
 (async () => {
   // await deviceListCheck();
-  // await loginCheck();
+  // await loginCheck(4);
 })()

--- a/example/index.js
+++ b/example/index.js
@@ -1,22 +1,40 @@
-//const WyzeAPI = require('../src/index') // Local Debug
-const WyzeAPI = require("wyze-api")
-const Logger = require("@ptkdev/logger");
+let WyzeAPI = null;
+if (process.env.LOCAL_DEV) {
+  WyzeAPI = require('../src/index'); // Local Debug
+} else {
+  WyzeAPI = require("wyze-api");
+}
 
+const Logger = require("@ptkdev/logger");
 const logger = new Logger();
 
 const options = {
-  username: "username",
-  password: "password",
-  keyId: "keyId",
-  apiKey: "apiKey",
-  persistPath: "./scratch",
-  logLevel: "debug",
-  apiLogEnabled: true
+  username: process.env.USERNAME,
+  password: process.env.PASSWORD,
+  keyId: process.env.KEY_ID,
+  apiKey: process.env.API_KEY,
+  persistPath: process.env.PERSIST_PATH,
+  logLevel: process.env.LOG_LEVEL,
+  apiLogEnabled: process.env.API_LOG_ENABLED,
 }
-const wyze = new WyzeAPI(options,logger)
+const wyze = new WyzeAPI(options, logger);
 
-  ; (async () => {
+async function loginCheck(iterations = 2) {
+  var count = 0;
+  while (count < iterations) {
+    await wyze.maybeLogin();
+    wyze.access_token = "";
+    count += 1;
+  }
+}
 
+async function deviceListCheck() {
   const devices = await wyze.getDeviceList()
-   logger.debug(JSON.stringify(devices))
-  })()
+  logger.debug(JSON.stringify(devices))
+}
+
+
+(async () => {
+  // await deviceListCheck();
+  await loginCheck();
+})()

--- a/src/index.js
+++ b/src/index.js
@@ -201,7 +201,7 @@ module.exports = class WyzeAPI {
   }
 
   async maybeLogin() {
-    if (!this.access_token) {
+    if (false && !this.access_token) {
       await this._loadPersistedTokens();
     }
 
@@ -226,7 +226,7 @@ module.exports = class WyzeAPI {
         var waitTime = 0;
         while (waitTime < this.loginAttemptDebounceMilliseconds) {
           await this.sleep(2);
-          waitTime = waitTime + 5000;
+          waitTime = waitTime + 2000;
           if (this.access_token) {
             break;
           }

--- a/src/index.js
+++ b/src/index.js
@@ -3,10 +3,11 @@ const fs = require("fs").promises;
 const path = require("path");
 const getUuid = require("uuid-by-string");
 
-const payloadFactory = require("./payloadFactory");
-const crypto = require("./crypto");
-const constants = require("./constants");
-const util = require("./util");
+const payloadFactory = require('./payloadFactory');
+const crypto = require('./crypto');
+const constants = require('./constants');
+const util = require('./util');
+const { time } = require('console');
 
 module.exports = class WyzeAPI {
   constructor(options, log) {
@@ -53,6 +54,9 @@ module.exports = class WyzeAPI {
     this.refresh_token = "";
 
     this.dumpData = false; // Set this to true to log the Wyze object data blob one time at startup.
+
+    this.lastLoginAttempt = 0;
+    this.loginAttemptDebounceMilliseconds = 1000;
 
     // Token is good for 216,000 seconds (60 hours) but 48 hours seems like a reasonable refresh interval 172800
     if (this.refreshTokenTimerEnabled === true) {
@@ -202,7 +206,38 @@ module.exports = class WyzeAPI {
     }
 
     if (!this.access_token) {
-      await this.login();
+      let now = new Date().getTime();
+      // check if the last login attempt occurred too recently
+      if (this.apiLogEnabled) this.log.debug("Last login " + this.lastLoginAttempt + " debounce " + this.loginAttemptDebounceMilliseconds + " now " + now);
+      if (this.lastLoginAttempt + this.loginAttemptDebounceMilliseconds < now) {
+        // reset loginAttemptDebounceMilliseconds if last attempted login occurred more than 12 hours ago
+        if (this.lastLoginAttempt - now > 60 * 1000 * 60 * 12) {
+          this.loginAttemptDebounceMilliseconds = 1000;
+        } else {
+          // max debounce of 5 minutes
+          this.loginAttemptDebounceMilliseconds = Math.min(this.loginAttemptDebounceMilliseconds * 2, 1000 * 60 * 5);
+        }
+
+        this.lastLoginAttempt = now;
+        await this.login();
+      } else {
+        this.log.warning("Attempting to login before debounce has cleared, waiting " + this.loginAttemptDebounceMilliseconds / 1000 + " seconds");
+
+        var waitTime = 0;
+        while (waitTime < this.loginAttemptDebounceMilliseconds) {
+          await this.sleep(2);
+          waitTime = waitTime + 5000;
+          if (this.access_token) {
+            break;
+          }
+        }
+
+        if (!this.access_token) {
+          this.lastLoginAttempt = now;
+          this.loginAttemptDebounceMilliseconds = Math.min(this.loginAttemptDebounceMilliseconds * 2, 1000 * 60 * 5);
+          await this.login();
+        }
+      }
     }
   }
 
@@ -1416,7 +1451,7 @@ module.exports = class WyzeAPI {
     return Math.max(min, Math.min(number, max));
   }
 
-  sleep(ms) {
-    return new Promise((resolve) => setTimeout(resolve, ms * 1000));
+  sleep(seconds) {
+    return new Promise((resolve) => setTimeout(resolve, seconds * 1000));
   }
 };

--- a/src/index.js
+++ b/src/index.js
@@ -201,7 +201,7 @@ module.exports = class WyzeAPI {
   }
 
   async maybeLogin() {
-    if (false && !this.access_token) {
+    if (!this.access_token) {
       await this._loadPersistedTokens();
     }
 


### PR DESCRIPTION
Update `maybeLogin` to check last login time and perform exponential backoff, up to 5 minutes. Debounce will reset back to 1s after 12 hours has passed, to prevent users from being stuck with a 5 minute polling interval in the case of a login.

In the event a user's password/api key do expire or are changed naturally, then during the config update the bridge/homebridge will be prompted to restart, resetting the debounce and allowing them to login promptly.

Should ameliorate issues in #6 

Update example to have parameters provided via env var.
Added .env.sample
Update sleep function to have correctly named parameter

Example can be run via `node --env-file=.env example`

Example run with `loginCheck(4)` and persisted token temporarily disabled. 

```
[22:24:21] ~/wyze-homebridge/wyze-api [debounce_login] λ node --env-file=.env example
 | DEBUG           2024-02-07 22:26:37   Last login 0 debounce 1000 now 1707366397148
 | DEBUG           2024-02-07 22:26:37   Performing request: api/user/login
 | DEBUG           2024-02-07 22:26:37   Request config: <SNIP>
 | DEBUG           2024-02-07 22:26:37   API response PerformRequest: <SNIP>
 | DEBUG           2024-02-07 22:26:37   scratch/wyze-63773091-e5d0-554a-8ba2-5a69db9191ee.json
 | DEBUG           2024-02-07 22:26:37   Successfully logged into Wyze API
 | DEBUG           2024-02-07 22:26:37   Last login 1707366397148 debounce 2000 now 1707366397684
 | WARNING         2024-02-07 22:26:37   Attempting to login before debounce has cleared, waiting 2 seconds
 | DEBUG           2024-02-07 22:26:39   Performing request: api/user/login
 | DEBUG           2024-02-07 22:26:39   Request config: <SNIP>
 | DEBUG           2024-02-07 22:26:40   API response PerformRequest: <SNIP>
 | DEBUG           2024-02-07 22:26:40   scratch/wyze-63773091-e5d0-554a-8ba2-5a69db9191ee.json
 | DEBUG           2024-02-07 22:26:40   Successfully logged into Wyze API
 | DEBUG           2024-02-07 22:26:40   Last login 1707366397684 debounce 4000 now 1707366400236
 | WARNING         2024-02-07 22:26:40   Attempting to login before debounce has cleared, waiting 4 seconds
 | DEBUG           2024-02-07 22:26:44   Performing request: api/user/login
 | DEBUG           2024-02-07 22:26:44   Request config: <SNIP>
 | DEBUG           2024-02-07 22:26:44   API response PerformRequest: <SNIP>
 | DEBUG           2024-02-07 22:26:44   scratch/wyze-63773091-e5d0-554a-8ba2-5a69db9191ee.json
 | DEBUG           2024-02-07 22:26:44   Successfully logged into Wyze API
 | DEBUG           2024-02-07 22:26:44   Last login 1707366400236 debounce 8000 now 1707366404582
 | WARNING         2024-02-07 22:26:44   Attempting to login before debounce has cleared, waiting 8 seconds
 | DEBUG           2024-02-07 22:26:52   Performing request: api/user/login
 | DEBUG           2024-02-07 22:26:52   Request config: <SNIP>
 | DEBUG           2024-02-07 22:26:54   API response PerformRequest: <SNIP>
 | DEBUG           2024-02-07 22:26:54   scratch/wyze-63773091-e5d0-554a-8ba2-5a69db9191ee.json
 | DEBUG           2024-02-07 22:26:54   Successfully logged into Wyze API
[22:26:54] ~/wyze-homebridge/wyze-api [debounce_login] λ 
```