### PR TITLE
Fix turnOn/turnOff methods for plugs and lights.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1158,7 +1158,7 @@ module.exports = class WyzeAPI {
     await this.setProperty(deviceMac, deviceModel, "P3", value);
   }
   async lightTurnOn(deviceMac, deviceModel) {
-    await this.lightPower(deviceMac, deviceModel, "P3", "1");
+    await this.setProperty(deviceMac, deviceModel, "P3", "1");
   }
   async lightTurnOff(deviceMac, deviceModel) {
     await this.setProperty(deviceMac, deviceModel, "P3", "0");

--- a/src/index.js
+++ b/src/index.js
@@ -1141,10 +1141,10 @@ module.exports = class WyzeAPI {
     await this.setProperty(deviceMac, deviceModel, "P3", value);
   }
   async plugTurnOn(deviceMac, deviceModel) {
-    await this.setProperty(deviceMac, deviceModel, "P3", "0");
+    await this.setProperty(deviceMac, deviceModel, "P3", "1");
   }
   async plugTurnOff(deviceMac, deviceModel) {
-    await this.setProperty(deviceMac, deviceModel, "P3", "1");
+    await this.setProperty(deviceMac, deviceModel, "P3", "0");
   }
 
   //WyzeLight
@@ -1158,10 +1158,10 @@ module.exports = class WyzeAPI {
     await this.setProperty(deviceMac, deviceModel, "P3", value);
   }
   async lightTurnOn(deviceMac, deviceModel) {
-    await this.setProperty(deviceMac, deviceModel, "P3", "0");
+    await this.lightPower(deviceMac, deviceModel, "P3", "1");
   }
   async lightTurnOff(deviceMac, deviceModel) {
-    await this.setProperty(deviceMac, deviceModel, "P3", "1");
+    await this.setProperty(deviceMac, deviceModel, "P3", "0");
   }
 
   async setBrightness(deviceMac, deviceModel, value) {


### PR DESCRIPTION
These methods were inadvertently reversed, turnOn was turning things off and turnOff was turning things on.

Note: the README refers to general turnOn / turnOff methods which do not exist (at least not in the current version).