### PR TITLE
Add camera WebRTC stream support + snapshot capture

### DIFF
--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -1,0 +1,27 @@
+# Sync the in-repo wiki/ directory to the project's GitHub Wiki.
+# Wikis live in a separate <repo>.wiki.git repository; this workflow keeps
+# them in lockstep with what's committed under wiki/ on the main branch.
+
+name: Sync wiki
+
+on:
+  workflow_dispatch: {}
+  push:
+    branches: [main]
+    paths:
+      - 'wiki/**'
+      - '.github/workflows/wiki-sync.yml'
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Push wiki/ to GitHub Wiki
+        uses: Andrew-Chen-Wang/github-wiki-action@v4
+        with:
+          path: wiki/

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ node_modules
 # ignore any persisted token files
 wyze-*.json
 example/scratch/*
+
+# Claude Code worktree state
+.claude/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,20 @@
 # wyze-api
 
 ## Releases
+### v1.1.10
+- Add camera WebRTC stream support. Port of [wyzeapy#230](https://github.com/SecKatie/wyzeapy/pull/230) plus production-ready helpers ported from the [`camera-stream`](https://github.com/jfarmer08/wyze-api/tree/camera-stream) reference branch.
+- Primary: `getCameraWebRTCConnectionInfo(mac, model, options)` — returns `{signalingUrl, iceServers, authToken, clientId, mac, model, substream, cached}`. ICE servers are normalized to `{urls, ...}` for `RTCPeerConnection`; signaling URL is decoded and (optionally) has the generated client ID injected as `X-Amz-ClientId`. 60s in-memory cache per `(mac, substream)`.
+- Convenience: `getCameraWebRTCConnectionInfoWithReconnect` (exponential-backoff retry), `cameraStreamWithReconnect` (general retry wrapper).
+- Lower-level: `cameraGetStreamInfo`, `cameraGetSignalingUrl`, `cameraGetIceServers` — all accept `{substream}` option.
+- Helpers: `createCameraStreamClientId`, `normalizeCameraSignalingUrl`, `setCameraSignalingClientId`, `sanitizeCameraIceServers`, `parseCameraStatus`, `clearCameraStreamCache`.
+- `WyzeAPI.StreamStatus` lifecycle constants (numeric values mirror docker-wyze-bridge).
+- Add `cameraCaptureSnapshot(mac, model, [options])` — headless WebRTC frame capture (negotiates a session, grabs one JPEG via ffmpeg, tears down). 10s per-mac cache. New deps: `werift`, `ws`, `ffmpeg-static` (bundled ffmpeg binary — no system install needed).
+- Add `getCameraSnapshotImage(mac, [options])` — unified image getter; tries cloud thumbnail first, falls back to live capture. Returns `{buffer, source}`.
+- Add camera lookup helpers: `getCameras`, `getOnlineCameras`, `getOfflineCameras`, `getCamera(mac)`, `getCameraByName(nickname)`, `getCameraSnapshot(mac)`, `getCameraSnapshotUrl(mac)`, `getCameraSummaries`.
+- Add pure device-object helpers: `cameraIsOnline`, `cameraGetThumbnail`, `cameraGetSnapshot`, `cameraToSummary`, `cameraGetSignalStrength`, `cameraGetIp`, `cameraGetFirmware`, `cameraGetTimezone`, `cameraGetLastSeen`.
+- Add `web_create_signature` crypto helper and `webAppId`/`webAppInfo`/`webSigningSecret` constants for the `app.wyze.com` web API.
+- New example: `example/viewer.js` + `example/public/viewer.html` — a browser-based WebRTC viewer that exercises all the new camera helpers end-to-end.
+
 ### v1.1.9
 - Add IoT3 API support for Lock Bolt V2 (DX_LB2) and Palm lock (DX_PVLOC)
 - Add `lockBoltV2GetProperties`, `lockBoltV2Lock`, `lockBoltV2Unlock` for Bolt V2

--- a/README.md
+++ b/README.md
@@ -90,6 +90,48 @@ Use these helper methods to interact with wyze-api.
 - wyze.cameraMotionRecordingOn(device.mac, device.product_model)
 - wyze.cameraMotionRecordingOff(device.mac, device.product_model)
 
+### Camera Stream Methods (WebRTC)
+
+These return the credentials a WebRTC client (werift, go2rtc, Kinesis Video Streams WebRTC SDK) needs to negotiate a live stream — they do **not** return a playable URL on their own.
+
+**Primary**:
+- wyze.getCameraWebRTCConnectionInfo(mac, model, [options]) — bundled, ready-to-use shape: `{signalingUrl, iceServers, authToken, clientId, mac, model, substream, cached}`. `iceServers` are normalized to the `{urls, ...}` shape `RTCPeerConnection` expects; `signalingUrl` has any double-encoding decoded and (by default) the generated `clientId` injected as `X-Amz-ClientId`. Cached for 60s per `(mac, substream)`. Options: `substream`, `includeClientId`, `clientId`, `clientIdPrefix`, `noCache`, `cacheTtlMs`.
+- wyze.getCameraWebRTCConnectionInfoWithReconnect(mac, model, [options], [retryOptions]) — same, with exponential-backoff retry. `retryOptions`: `{maxAttempts=3, baseDelayMs=2000, onRetry}`.
+
+**Lower-level**:
+- wyze.cameraGetStreamInfo(mac, model, [options]) — raw API shape `{signaling_url, ice_servers, auth_token, ...}`. `options.substream` requests the lower-bitrate sub stream.
+- wyze.cameraGetSignalingUrl(mac, model, [options]) — just the raw signaling URL string
+- wyze.cameraGetIceServers(mac, model, [options]) — just the raw ICE/STUN/TURN server list
+
+**Helpers**:
+- wyze.createCameraStreamClientId(deviceOrMac, [prefix="viewer"]) — generate a unique viewer client ID
+- wyze.normalizeCameraSignalingUrl(url) — fix double-encoded Kinesis URLs
+- wyze.sanitizeCameraIceServers(iceServers) — convert `{url}` entries to `{urls}` for `RTCPeerConnection`
+- wyze.parseCameraStatus(streamInfoResponse) — non-throwing parse → `{online, powered}` or `null`
+- wyze.cameraStreamWithReconnect(fn, [retryOptions]) — exponential-backoff retry wrapper for any stream call
+- wyze.clearCameraStreamCache([mac]) — clear cached stream info (one camera or all)
+- WyzeAPI.StreamStatus — lifecycle constants (`OFFLINE`, `STOPPING`, `DISABLED`, `STOPPED`, `CONNECTING`, `CONNECTED`)
+
+### Camera Helper Methods
+
+Pure (sync, take a device object):
+- wyze.cameraIsOnline(device) — true if `device.device_params.status === 1`
+- wyze.cameraGetThumbnail(device) — first thumbnail URL, or null
+- wyze.cameraGetSnapshot(device) — first thumbnail object (`{url, type, ts, ...}`), or null
+- wyze.cameraToSummary(device) — `{mac, productModel, nickname, online, thumbnail}`
+- wyze.cameraGetSignalStrength(device) / cameraGetIp(device) / cameraGetFirmware(device) / cameraGetTimezone(device) / cameraGetLastSeen(device)
+
+Lookups (async):
+- wyze.getCameras() — list of all camera devices
+- wyze.getOnlineCameras() / getOfflineCameras()
+- wyze.getCamera(mac) — by MAC, or undefined
+- wyze.getCameraByName(nickname) — by nickname (case-insensitive)
+- wyze.getCameraSnapshot(mac) — cloud snapshot metadata object (or null)
+- wyze.getCameraSnapshotUrl(mac) — cloud snapshot URL only
+- wyze.getCameraSummaries() — summaries for all cameras
+- wyze.cameraCaptureSnapshot(mac, model, [options]) — capture a JPEG frame from the live WebRTC stream. ffmpeg is provided by the bundled `ffmpeg-static` npm dep — no system install. Cached per-mac for `cacheTtlMs` (default 10s). Returns a `Buffer`.
+- wyze.getCameraSnapshotImage(mac, [options]) — returns `{buffer, source}` where `source` is `"cloud"` or `"capture"`. Tries the cloud thumbnail first; on missing or download failure, falls back to `cameraCaptureSnapshot`. Pass `skipCloud: true` to go straight to live capture.
+
 ### Plug Methods
 - wyze.plugPower(device.mac, device.product_model, value)
 - wyze.plugTurnOn(device.mac, device.product_model)

--- a/example/.env.example
+++ b/example/.env.example
@@ -5,3 +5,5 @@ API_KEY="my-api-key"
 LOCAL_DEV=true
 PERSIST_PATH="./"
 API_LOG_ENABLED=true
+# Port for example/viewer.js (defaults to 3030)
+VIEWER_PORT="3030"

--- a/example/package.json
+++ b/example/package.json
@@ -5,6 +5,8 @@
   "homepage": "https://github.com/jfarmer08/wyze-api",
   "main": "index.js",
   "scripts": {
+    "start": "node index.js",
+    "viewer": "node viewer.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [

--- a/example/public/viewer.html
+++ b/example/public/viewer.html
@@ -1,0 +1,626 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Wyze Camera Viewer</title>
+    <style>
+      :root {
+        color-scheme: dark;
+      }
+      *,
+      *::before,
+      *::after {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        font-family:
+          Inter,
+          system-ui,
+          -apple-system,
+          Segoe UI,
+          Roboto,
+          sans-serif;
+        background: #0b1020;
+        color: #e8ecff;
+      }
+      header {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        flex-wrap: wrap;
+        padding: 14px 20px;
+        background: #101828;
+        border-bottom: 1px solid #1e2d50;
+      }
+      header h2 {
+        margin: 0;
+        font-size: 1rem;
+        flex: 1;
+        white-space: nowrap;
+      }
+      .toolbar {
+        display: flex;
+        gap: 8px;
+        flex-wrap: wrap;
+        align-items: center;
+      }
+      button,
+      select {
+        background: #0f1430;
+        color: #e8ecff;
+        border: 1px solid #33407a;
+        border-radius: 8px;
+        padding: 7px 12px;
+        font-size: 0.85rem;
+        cursor: pointer;
+      }
+      button:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+      }
+      button.active {
+        background: #1e3a8a;
+        border-color: #6495ed;
+      }
+      button.danger {
+        border-color: #7a3333;
+      }
+      button.danger:hover {
+        background: #3a1010;
+      }
+      #statusBar {
+        padding: 6px 20px;
+        font-size: 0.8rem;
+        background: #0d1525;
+        border-bottom: 1px solid #1e2d50;
+        min-height: 28px;
+      }
+      #grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(420px, 1fr));
+        gap: 12px;
+        padding: 16px;
+      }
+      .cam-tile {
+        background: #111827;
+        border: 1px solid #1e2d50;
+        border-radius: 10px;
+        overflow: hidden;
+        display: flex;
+        flex-direction: column;
+      }
+      .cam-tile-header {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 8px 10px;
+        background: #151c34;
+        font-size: 0.82rem;
+        min-height: 36px;
+      }
+      .cam-name {
+        flex: 1;
+        font-weight: 600;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      .cam-badge {
+        font-size: 0.7rem;
+        padding: 2px 7px;
+        border-radius: 20px;
+        white-space: nowrap;
+      }
+      .badge-online {
+        background: #14532d;
+        color: #86efac;
+      }
+      .badge-offline {
+        background: #3b0000;
+        color: #fca5a5;
+      }
+      .badge-connecting {
+        background: #1e3a00;
+        color: #d9f99d;
+      }
+      .badge-streaming {
+        background: #0c4a6e;
+        color: #7dd3fc;
+      }
+      .badge-error {
+        background: #450a0a;
+        color: #fca5a5;
+      }
+      .cam-video-wrap {
+        position: relative;
+        background: #000;
+        aspect-ratio: 16/9;
+      }
+      .cam-video-wrap video {
+        width: 100%;
+        height: 100%;
+        object-fit: contain;
+        display: block;
+      }
+      .cam-overlay {
+        position: absolute;
+        inset: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 0.85rem;
+        color: #94a3b8;
+        background: rgba(0, 0, 0, 0.55);
+        pointer-events: none;
+      }
+      .cam-overlay.hidden {
+        display: none;
+      }
+      .cam-thumb {
+        position: absolute;
+        inset: 0;
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        opacity: 0.35;
+      }
+      .cam-footer {
+        display: flex;
+        gap: 6px;
+        padding: 6px 8px;
+        background: #151c34;
+        border-top: 1px solid #1e2d50;
+        align-items: center;
+      }
+      .cam-footer button {
+        padding: 5px 10px;
+        font-size: 0.78rem;
+      }
+      .cam-log {
+        font-size: 0.72rem;
+        color: #64748b;
+        padding: 4px 8px 6px;
+        max-height: 56px;
+        overflow-y: auto;
+        font-family: monospace;
+        line-height: 1.4;
+      }
+      .log-ok {
+        color: #86efac;
+      }
+      .log-warn {
+        color: #fde68a;
+      }
+      .log-err {
+        color: #fca5a5;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h2>📷 Wyze Camera Viewer</h2>
+      <div class="toolbar">
+        <button id="refreshBtn">↺ Refresh</button>
+        <button id="snapshotAllBtn">📸 Snapshot All</button>
+        <button id="startAllBtn">▶ Start All</button>
+        <button id="stopAllBtn" class="danger">■ Stop All</button>
+        <button id="substreamBtn">Sub-stream: OFF</button>
+      </div>
+    </header>
+    <div id="statusBar">Loading cameras…</div>
+    <div id="grid"></div>
+
+    <script>
+      let cameras = [];
+      let useSubstream = false;
+      const streams = new Map();
+
+      const statusBar = document.getElementById("statusBar");
+      const grid = document.getElementById("grid");
+      const refreshBtn = document.getElementById("refreshBtn");
+      const snapshotAllBtn = document.getElementById("snapshotAllBtn");
+      const startAllBtn = document.getElementById("startAllBtn");
+      const stopAllBtn = document.getElementById("stopAllBtn");
+      const substreamBtn = document.getElementById("substreamBtn");
+
+      substreamBtn.addEventListener("click", () => {
+        useSubstream = !useSubstream;
+        substreamBtn.textContent = `Sub-stream: ${useSubstream ? "ON" : "OFF"}`;
+        substreamBtn.classList.toggle("active", useSubstream);
+      });
+
+      function b64Encode(value) {
+        return btoa(unescape(encodeURIComponent(value)));
+      }
+      function b64Decode(value) {
+        const norm = String(value || "")
+          .replace(/-/g, "+")
+          .replace(/_/g, "/");
+        const padded = norm + "=".repeat((4 - (norm.length % 4)) % 4);
+        return decodeURIComponent(escape(atob(padded)));
+      }
+      function parseSignalPayload(raw) {
+        if (!raw || raw === "null") return null;
+        const s = String(raw);
+        for (const fn of [() => JSON.parse(s), () => JSON.parse(b64Decode(s))]) {
+          try {
+            return fn();
+          } catch (_) {}
+        }
+        return null;
+      }
+      function escHtml(str) {
+        return String(str).replace(
+          /[&<>"']/g,
+          (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[c]
+        );
+      }
+
+      class StreamSession {
+        constructor(camera, elements) {
+          this.camera = camera;
+          this.els = elements;
+          this.pc = null;
+          this.ws = null;
+          this.pendingCandidates = [];
+          this.hasRemoteDesc = false;
+          this.isApplyingRemoteAnswer = false;
+          this.sessionToken = 0;
+          this.startWaiters = [];
+          this.incompatibleRetryCount = 0;
+        }
+
+        log(msg, level = "") {
+          const ts = new Date().toTimeString().slice(0, 8);
+          const line = document.createElement("div");
+          if (level) line.className = `log-${level}`;
+          line.textContent = `[${ts}] ${msg}`;
+          this.els.logEl.appendChild(line);
+          this.els.logEl.scrollTop = this.els.logEl.scrollHeight;
+        }
+
+        setBadge(text, cls) {
+          this.els.badge.textContent = text;
+          this.els.badge.className = `cam-badge ${cls}`;
+        }
+
+        setOverlay(text) {
+          if (text) {
+            this.els.overlay.textContent = text;
+            this.els.overlay.classList.remove("hidden");
+          } else {
+            this.els.overlay.classList.add("hidden");
+          }
+        }
+
+        ensureThumbEl() {
+          if (this.els.thumb) return this.els.thumb;
+          const thumb = document.createElement("img");
+          thumb.className = "cam-thumb";
+          thumb.alt = "";
+          this.els.video.parentElement.insertBefore(thumb, this.els.video);
+          this.els.thumb = thumb;
+          return thumb;
+        }
+
+        _resolveStartWaiters(value) {
+          const waiters = this.startWaiters;
+          this.startWaiters = [];
+          for (const resolve of waiters) {
+            resolve(value);
+          }
+        }
+
+        _waitForStartResult(timeoutMs = 2500) {
+          return new Promise((resolve) => {
+            const timer = setTimeout(() => resolve(false), timeoutMs);
+            this.startWaiters.push((value) => {
+              clearTimeout(timer);
+              resolve(value);
+            });
+          });
+        }
+
+        async start(isRetry = false) {
+          this.stop();
+          if (!isRetry) {
+            this.incompatibleRetryCount = 0;
+          }
+          const sessionToken = ++this.sessionToken;
+          if (!this.camera.online) {
+            this.setBadge("Offline", "badge-offline");
+            this.setOverlay("Camera offline");
+            this._resolveStartWaiters(false);
+            return;
+          }
+          this.setBadge("Connecting…", "badge-connecting");
+          this.setOverlay("Fetching stream…");
+          this.els.startBtn.disabled = true;
+
+          try {
+            const res = await fetch(
+              `/api/stream-params?mac=${encodeURIComponent(this.camera.mac)}` +
+                `&productModel=${encodeURIComponent(this.camera.productModel)}` +
+                `&substream=${useSubstream}`
+            );
+            const data = await res.json();
+            if (!res.ok) throw new Error(data.error || "Failed to fetch stream params");
+            this._connect(data.params.signalingUrl, data.params.iceServers, sessionToken);
+            return await this._waitForStartResult();
+          } catch (err) {
+            this.log(err.message, "err");
+            this.setBadge("Error", "badge-error");
+            this.setOverlay("Failed: " + err.message);
+            this.els.startBtn.disabled = false;
+            this._resolveStartWaiters(false);
+            return false;
+          }
+        }
+
+        async refreshSnapshot() {
+          try {
+            this.log("Fetching snapshot…");
+            const url = `/api/snapshot?mac=${encodeURIComponent(this.camera.mac)}&ts=${Date.now()}`;
+            const res = await fetch(url);
+            if (!res.ok) {
+              const data = await res.json().catch(() => ({}));
+              throw new Error(data.error || `HTTP ${res.status}`);
+            }
+            const source = res.headers.get("X-Snapshot-Source") || "cloud";
+            this.ensureThumbEl().src = url;
+            this.log(`Snapshot updated (${source})`, "ok");
+          } catch (err) {
+            this.log(`Snapshot error: ${err.message}`, "err");
+          }
+        }
+
+        _connect(signalingUrl, iceServers, sessionToken) {
+          this.log("Connecting…");
+          this.pc = new RTCPeerConnection({ iceServers });
+
+          this.pc.ontrack = (event) => {
+            if (sessionToken !== this.sessionToken) return;
+            this.log("Streaming", "ok");
+            this.els.video.srcObject = event.streams[0];
+            this.setOverlay(null);
+            this.setBadge("● Live", "badge-streaming");
+            this._resolveStartWaiters(true);
+          };
+
+          this.pc.onicecandidate = (event) => {
+            if (sessionToken !== this.sessionToken) return;
+            if (event.candidate) this._send("ICE_CANDIDATE", event.candidate, "MASTER");
+          };
+
+          this.pc.onconnectionstatechange = () => {
+            if (sessionToken !== this.sessionToken) return;
+            const s = this.pc?.connectionState;
+            if (s === "failed" || s === "disconnected") {
+              this.log(`Connection ${s}`, "warn");
+              this.setBadge(s === "failed" ? "Error" : "Disconnected", "badge-error");
+              this._resolveStartWaiters(false);
+            }
+          };
+
+          this.pc.addTransceiver("video", { direction: "recvonly" });
+
+          this.ws = new WebSocket(signalingUrl);
+
+          this.ws.onopen = async () => {
+            if (sessionToken !== this.sessionToken || !this.pc) return;
+            this.log("Signaling connected", "ok");
+            this.setOverlay("Negotiating…");
+            const offer = await this.pc.createOffer();
+            await this.pc.setLocalDescription(offer);
+            this._send("SDP_OFFER", offer, "MASTER");
+          };
+
+          this.ws.onmessage = async (event) => {
+            if (sessionToken !== this.sessionToken || !this.pc) return;
+            if (typeof event.data !== "string" || event.data.length === 0) return;
+            try {
+              const env = JSON.parse(event.data);
+              const type = env.messageType || env.action;
+              const payload = parseSignalPayload(env.messagePayload);
+              if (!payload) return;
+
+              if (type === "SDP_ANSWER") {
+                if (
+                  this.hasRemoteDesc ||
+                  this.isApplyingRemoteAnswer ||
+                  this.pc.signalingState !== "have-local-offer"
+                ) {
+                  this.log("Ignoring late SDP answer", "warn");
+                  return;
+                }
+                this.isApplyingRemoteAnswer = true;
+                try {
+                  await this.pc.setRemoteDescription(new RTCSessionDescription(payload));
+                  this.hasRemoteDesc = true;
+                  this.log("SDP answer");
+                  for (const c of this.pendingCandidates) await this.pc.addIceCandidate(c);
+                  this.pendingCandidates = [];
+                } catch (err) {
+                  if (
+                    String(err?.message || "")
+                      .toLowerCase()
+                      .includes("incompatible send direction")
+                  ) {
+                    this.log("Incompatible SDP answer", "warn");
+                    this._resolveStartWaiters(false);
+
+                    if (this.incompatibleRetryCount < 1) {
+                      this.incompatibleRetryCount += 1;
+                      this.log("Retrying negotiation…", "warn");
+                      setTimeout(() => {
+                        if (sessionToken !== this.sessionToken) return;
+                        this.start(true).catch(() => {});
+                      }, 500);
+                    } else {
+                      this.setBadge("Error", "badge-error");
+                      this.setOverlay("Incompatible SDP from camera");
+                      this.els.startBtn.disabled = false;
+                    }
+                    return;
+                  }
+                  throw err;
+                } finally {
+                  this.isApplyingRemoteAnswer = false;
+                }
+              }
+              if (type === "ICE_CANDIDATE") {
+                const c = new RTCIceCandidate(payload);
+                if (!this.hasRemoteDesc) this.pendingCandidates.push(c);
+                else if (this.pc.remoteDescription) await this.pc.addIceCandidate(c);
+              }
+            } catch (err) {
+              this.log(`Signal error: ${err.message}`, "err");
+              this._resolveStartWaiters(false);
+            }
+          };
+
+          this.ws.onerror = () => this.log("WebSocket error", "err");
+          this.ws.onclose = (e) => {
+            if (sessionToken !== this.sessionToken) return;
+            if (e.code !== 1000) this.log(`WS closed (${e.code})`, "warn");
+            this._resolveStartWaiters(false);
+          };
+        }
+
+        _send(action, payload, recipientClientId = "") {
+          if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
+          this.ws.send(
+            JSON.stringify({
+              action,
+              messagePayload: b64Encode(JSON.stringify(payload)),
+              recipientClientId,
+            })
+          );
+        }
+
+        stop() {
+          this.sessionToken += 1;
+          this.pendingCandidates = [];
+          this.hasRemoteDesc = false;
+          this.isApplyingRemoteAnswer = false;
+          if (this.ws) {
+            this.ws.close();
+            this.ws = null;
+          }
+          if (this.pc) {
+            this.pc.getSenders().forEach((s) => s.track?.stop());
+            this.pc.getReceivers().forEach((r) => r.track?.stop());
+            this.pc.close();
+            this.pc = null;
+          }
+          this.els.video.srcObject = null;
+          this.setBadge(
+            this.camera.online ? "Online" : "Offline",
+            this.camera.online ? "badge-online" : "badge-offline"
+          );
+          this.setOverlay(this.camera.online ? "Click Start" : "Camera offline");
+          this.els.startBtn.disabled = !this.camera.online;
+          this._resolveStartWaiters(false);
+        }
+      }
+
+      function buildGrid(cameraList) {
+        streams.forEach((s) => s.stop());
+        streams.clear();
+        grid.innerHTML = "";
+
+        for (const camera of cameraList) {
+          const tile = document.createElement("div");
+          tile.className = "cam-tile";
+          tile.innerHTML = `
+            <div class="cam-tile-header">
+              <span class="cam-name">${escHtml(camera.nickname)}</span>
+              <span class="cam-badge ${camera.online ? "badge-online" : "badge-offline"}">
+                ${camera.online ? "Online" : "Offline"}
+              </span>
+            </div>
+            <div class="cam-video-wrap">
+              ${
+                camera.thumbnail
+                  ? `<img class="cam-thumb" src="/api/thumbnail?url=${encodeURIComponent(camera.thumbnail)}" alt="" />`
+                  : ""
+              }
+              <video autoplay playsinline muted></video>
+              <div class="cam-overlay">${camera.online ? "Click Start" : "Camera offline"}</div>
+            </div>
+            <div class="cam-log"></div>
+            <div class="cam-footer">
+              <button class="start-btn" ${camera.online ? "" : "disabled"}>▶ Start</button>
+              <button class="snapshot-btn">📸 Snapshot</button>
+              <button class="stop-btn">■ Stop</button>
+              <span style="flex:1"></span>
+              <span style="font-size:0.72rem;color:#475569">${escHtml(camera.productModel)}</span>
+            </div>`;
+
+          grid.appendChild(tile);
+
+          const els = {
+            video: tile.querySelector("video"),
+            thumb: tile.querySelector(".cam-thumb"),
+            overlay: tile.querySelector(".cam-overlay"),
+            badge: tile.querySelector(".cam-badge"),
+            logEl: tile.querySelector(".cam-log"),
+            startBtn: tile.querySelector(".start-btn"),
+            snapshotBtn: tile.querySelector(".snapshot-btn"),
+            stopBtn: tile.querySelector(".stop-btn"),
+          };
+
+          const session = new StreamSession(camera, els);
+          streams.set(camera.mac, session);
+
+          els.startBtn.addEventListener("click", () => session.start());
+          els.snapshotBtn.addEventListener("click", () => session.refreshSnapshot());
+          els.stopBtn.addEventListener("click", () => session.stop());
+        }
+      }
+
+      async function loadCameras() {
+        statusBar.textContent = "Loading cameras…";
+        const res = await fetch("/api/cameras");
+        const data = await res.json();
+        if (!res.ok) throw new Error(data.error || "Failed to load cameras");
+        cameras = data.cameras;
+        buildGrid(cameras);
+        const online = cameras.filter((c) => c.online).length;
+        statusBar.textContent = `${cameras.length} cameras — ${online} online`;
+      }
+
+      refreshBtn.addEventListener("click", async () => {
+        try {
+          await loadCameras();
+        } catch (err) {
+          statusBar.textContent = "Error: " + err.message;
+        }
+      });
+
+      snapshotAllBtn.addEventListener("click", () => {
+        let delay = 0;
+        for (const session of streams.values()) {
+          setTimeout(() => session.refreshSnapshot(), delay);
+          delay += 150;
+        }
+      });
+
+      startAllBtn.addEventListener("click", async () => {
+        for (const session of streams.values()) {
+          if (!session.camera.online) continue;
+          await session.start();
+          await new Promise((resolve) => setTimeout(resolve, 1000));
+        }
+      });
+
+      stopAllBtn.addEventListener("click", () => streams.forEach((s) => s.stop()));
+
+      loadCameras().catch((err) => {
+        statusBar.textContent = "Error: " + err.message;
+      });
+    </script>
+  </body>
+</html>

--- a/example/viewer.js
+++ b/example/viewer.js
@@ -1,0 +1,154 @@
+/**
+ * Minimal HTTP server backing example/public/viewer.html — a browser-based
+ * Wyze camera viewer that uses WebRTC to play live streams.
+ *
+ * Run:    node viewer.js
+ * Open:   http://localhost:3030
+ *
+ * Routes:
+ *   GET /                              — serves viewer.html
+ *   GET /api/cameras                   — { cameras: [...summaries] }
+ *   GET /api/stream-params?mac=&productModel=&substream=&clientId=
+ *                                      — { params: { signalingUrl, iceServers, clientId? }, cached }
+ *   GET /api/snapshot?mac=             — { available, snapshot? }
+ *   GET /api/thumbnail?url=            — proxies a thumbnail image (CORS workaround)
+ *   GET /api/health                    — { ok: true }
+ */
+
+require("dotenv").config();
+
+const http = require("http");
+const fs = require("fs");
+const path = require("path");
+const { URL } = require("url");
+const https = require("https");
+
+const WyzeAPI = process.env.LOCAL_DEV ? require("../src/index") : require("wyze-api");
+
+const wyze = new WyzeAPI({
+  username: process.env.USERNAME,
+  password: process.env.PASSWORD,
+  keyId: process.env.KEY_ID,
+  apiKey: process.env.API_KEY,
+  persistPath: process.env.PERSIST_PATH,
+  logLevel: process.env.LOG_LEVEL,
+  apiLogEnabled: process.env.API_LOG_ENABLED,
+});
+
+const port = Number(process.env.VIEWER_PORT || 3030);
+const viewerHtmlPath = path.join(__dirname, "public", "viewer.html");
+
+function sendJson(res, statusCode, payload) {
+  res.writeHead(statusCode, { "Content-Type": "application/json" });
+  res.end(JSON.stringify(payload));
+}
+
+function sendHtml(res, html) {
+  res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
+  res.end(html);
+}
+
+const server = http.createServer(async (req, res) => {
+  try {
+    const requestUrl = new URL(req.url, `http://${req.headers.host}`);
+
+    if (req.method === "GET" && requestUrl.pathname === "/") {
+      sendHtml(res, fs.readFileSync(viewerHtmlPath, "utf8"));
+      return;
+    }
+
+    if (req.method === "GET" && requestUrl.pathname === "/api/cameras") {
+      await wyze.maybeLogin();
+      sendJson(res, 200, { cameras: await wyze.getCameraSummaries() });
+      return;
+    }
+
+    if (req.method === "GET" && requestUrl.pathname === "/api/stream-params") {
+      const mac = requestUrl.searchParams.get("mac");
+      const productModel = requestUrl.searchParams.get("productModel");
+      const substream = requestUrl.searchParams.get("substream") === "true";
+
+      if (!mac || !productModel) {
+        sendJson(res, 400, { error: "Missing mac or productModel" });
+        return;
+      }
+
+      await wyze.maybeLogin();
+      // Use the signed URL as-is — never inject a client ID, which would
+      // invalidate the AWS SigV4 signature and trigger WebSocket close 1006.
+      const params = await wyze.getCameraWebRTCConnectionInfo(mac, productModel, {
+        substream,
+        noCache: true,
+      });
+      sendJson(res, 200, { params, cached: params.cached });
+      return;
+    }
+
+    if (req.method === "GET" && requestUrl.pathname === "/api/snapshot") {
+      const mac = requestUrl.searchParams.get("mac");
+      if (!mac) {
+        sendJson(res, 400, { error: "Missing mac" });
+        return;
+      }
+      await wyze.maybeLogin();
+      try {
+        const { buffer, source } = await wyze.getCameraSnapshotImage(mac);
+        res.writeHead(200, {
+          "Content-Type": "image/jpeg",
+          "Content-Length": buffer.length,
+          "Cache-Control": "public, max-age=10",
+          "X-Snapshot-Source": source,
+        });
+        res.end(buffer);
+      } catch (error) {
+        sendJson(res, 502, { error: `Snapshot failed: ${error.message}` });
+      }
+      return;
+    }
+
+    if (req.method === "GET" && requestUrl.pathname === "/api/thumbnail") {
+      const thumbUrl = requestUrl.searchParams.get("url");
+      if (!thumbUrl) {
+        sendJson(res, 400, { error: "Missing url" });
+        return;
+      }
+      const client = thumbUrl.startsWith("https") ? https : http;
+      client
+        .get(thumbUrl, (upstream) => {
+          res.writeHead(upstream.statusCode, {
+            "Content-Type": upstream.headers["content-type"] || "image/jpeg",
+            "Cache-Control": "public, max-age=60",
+          });
+          upstream.pipe(res);
+        })
+        .on("error", (err) => sendJson(res, 502, { error: err.message }));
+      return;
+    }
+
+    if (req.method === "GET" && requestUrl.pathname === "/api/health") {
+      sendJson(res, 200, { ok: true });
+      return;
+    }
+
+    // Debug: dump the raw device list so you can confirm which fields exist
+    // (e.g., conn_state vs device_params.status). Useful when cameraIsOnline
+    // is wrong.
+    if (req.method === "GET" && requestUrl.pathname === "/api/debug/devices") {
+      await wyze.maybeLogin();
+      const cameras = await wyze.getCameras();
+      sendJson(res, 200, { count: cameras.length, cameras });
+      return;
+    }
+
+    sendJson(res, 404, { error: "Not found" });
+  } catch (error) {
+    sendJson(res, 500, {
+      error: error.message,
+      response: error.response?.data || null,
+    });
+  }
+});
+
+server.listen(port, () => {
+  console.log(`Wyze viewer running: http://localhost:${port}`);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wyze-api",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wyze-api",
-      "version": "1.1.9",
+      "version": "1.1.10",
       "funding": [
         {
           "type": "paypal",
@@ -29,11 +29,38 @@
         "base64-js": "1.5.1",
         "colorsys": "^1.0.22",
         "crypto-js": "4.2.0",
+        "ffmpeg-static": "^5.3.0",
         "moment": "2.29.4",
         "querystring": "0.2.1",
         "urllib": "3.18.0",
         "utf8": "3.0.0",
-        "uuid-by-string": "4.0.0"
+        "uuid-by-string": "4.0.0",
+        "werift": "^0.20.1",
+        "ws": "^8.20.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@derhuerst/http-basic": {
+      "version": "8.2.4",
+      "resolved": "https://registry.npmjs.org/@derhuerst/http-basic/-/http-basic-8.2.4.tgz",
+      "integrity": "sha512-F9rL9k9Xjf5blCz8HsJRO4diy111cayL2vkY2XE4r4t3n0yPXVYy3KD3nJ1qbrSn9743UWSXH4IwuCa/HWlGFw==",
+      "license": "MIT",
+      "dependencies": {
+        "caseless": "^0.12.0",
+        "concat-stream": "^2.0.0",
+        "http-response-object": "^3.0.1",
+        "parse-cache-control": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@fastify/busboy": {
@@ -42,6 +69,215 @@
       "integrity": "sha512-+KpH+QxZU7O4675t3mnkQKcZZg56u+K/Ct2K+N2AZYNVK8kyeo/bI18tI8aPm3tvNNRyTWfj6s5tnGNlcbQRsA==",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@fidm/asn1": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@fidm/asn1/-/asn1-1.0.4.tgz",
+      "integrity": "sha512-esd1jyNvRb2HVaQGq2Gg8Z0kbQPXzV9Tq5Z14KNIov6KfFD6PTaRIO8UpcsYiTNzOqJpmyzWgVTrUwFV3UF4TQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@fidm/x509": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@fidm/x509/-/x509-1.2.1.tgz",
+      "integrity": "sha512-nwc2iesjyc9hkuzcrMCBXQRn653XuAUKorfWM8PZyJawiy1QzLj4vahwzaI25+pfpwOLvMzbJ0uKpWLDNmo16w==",
+      "license": "MIT",
+      "dependencies": {
+        "@fidm/asn1": "^1.0.4",
+        "tweetnacl": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@leichtgewicht/ip-codec": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
+      "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
+      "license": "MIT"
+    },
+    "node_modules/@minhducsun2002/leb128": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@minhducsun2002/leb128/-/leb128-1.0.0.tgz",
+      "integrity": "sha512-eFrYUPDVHeuwWHluTG1kwNQUEUcFjVKYwPkU8z9DR1JH3AW7JtJsG9cRVGmwz809kKtGfwGJj58juCZxEvnI/g==",
+      "license": "MIT"
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@peculiar/asn1-cms": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.6.1.tgz",
+      "integrity": "sha512-vdG4fBF6Lkirkcl53q6eOdn3XYKt+kJTG59edgRZORlg/3atWWEReRCx5rYE1ZzTTX6vLK5zDMjHh7vbrcXGtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "@peculiar/asn1-x509-attr": "^2.6.1",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-csr": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.6.1.tgz",
+      "integrity": "sha512-WRWnKfIocHyzFYQTka8O/tXCiBquAPSrRjXbOkHbO4qdmS6loffCEGs+rby6WxxGdJCuunnhS2duHURhjyio6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-ecc": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.6.1.tgz",
+      "integrity": "sha512-+Vqw8WFxrtDIN5ehUdvlN2m73exS2JVG0UAyfVB31gIfor3zWEAQPD+K9ydCxaj3MLen9k0JhKpu9LqviuCE1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pfx": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.6.1.tgz",
+      "integrity": "sha512-nB5jVQy3MAAWvq0KY0R2JUZG8bO/bTLpnwyOzXyEh/e54ynGTatAR+csOnXkkVD9AFZ2uL8Z7EV918+qB1qDvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.6.1",
+        "@peculiar/asn1-pkcs8": "^2.6.1",
+        "@peculiar/asn1-rsa": "^2.6.1",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pkcs8": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.6.1.tgz",
+      "integrity": "sha512-JB5iQ9Izn5yGMw3ZG4Nw3Xn/hb/G38GYF3lf7WmJb8JZUydhVGEjK/ZlFSWhnlB7K/4oqEs8HnfFIKklhR58Tw==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pkcs9": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.6.1.tgz",
+      "integrity": "sha512-5EV8nZoMSxeWmcxWmmcolg22ojZRgJg+Y9MX2fnE2bGRo5KQLqV5IL9kdSQDZxlHz95tHvIq9F//bvL1OeNILw==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.6.1",
+        "@peculiar/asn1-pfx": "^2.6.1",
+        "@peculiar/asn1-pkcs8": "^2.6.1",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "@peculiar/asn1-x509-attr": "^2.6.1",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-rsa": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.6.1.tgz",
+      "integrity": "sha512-1nVMEh46SElUt5CB3RUTV4EG/z7iYc7EoaDY5ECwganibQPkZ/Y2eMsTKB/LeyrUJ+W/tKoD9WUqIy8vB+CEdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-schema": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.6.0.tgz",
+      "integrity": "sha512-xNLYLBFTBKkCzEZIw842BxytQQATQv+lDTCEMZ8C196iJcJJMBUZxrhSTxLaohMyKK8QlzRNTRkUmanucnDSqg==",
+      "license": "MIT",
+      "dependencies": {
+        "asn1js": "^3.0.6",
+        "pvtsutils": "^1.3.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.6.1.tgz",
+      "integrity": "sha512-O9jT5F1A2+t3r7C4VT7LYGXqkGLK7Kj1xFpz7U0isPrubwU5PbDoyYtx6MiGst29yq7pXN5vZbQFKRCP+lLZlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "asn1js": "^3.0.6",
+        "pvtsutils": "^1.3.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509-attr": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.6.1.tgz",
+      "integrity": "sha512-tlW6cxoHwgcQghnJwv3YS+9OO1737zgPogZ+CgWRUK4roEwIPzRH4JEiG770xe5HX2ATfCpmX60gurfWIF9dcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/x509": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/x509/-/x509-1.14.3.tgz",
+      "integrity": "sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.6.0",
+        "@peculiar/asn1-csr": "^2.6.0",
+        "@peculiar/asn1-ecc": "^2.6.0",
+        "@peculiar/asn1-pkcs9": "^2.6.0",
+        "@peculiar/asn1-rsa": "^2.6.0",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.0",
+        "pvtsutils": "^1.3.6",
+        "reflect-metadata": "^0.2.2",
+        "tslib": "^2.8.1",
+        "tsyringe": "^4.10.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@ptkdev/logger": {
@@ -57,6 +293,57 @@
       },
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@shinyoshiaki/binary-data": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@shinyoshiaki/binary-data/-/binary-data-0.6.1.tgz",
+      "integrity": "sha512-7HDb/fQAop2bCmvDIzU5+69i+UJaFgIVp99h1VzK1mpg1JwSODOkjbqD7ilTYnqlnadF8C4XjpwpepxDsGY6+w==",
+      "license": "MIT",
+      "dependencies": {
+        "generate-function": "^2.3.1",
+        "is-plain-object": "^2.0.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@shinyoshiaki/ebml-builder": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@shinyoshiaki/ebml-builder/-/ebml-builder-0.0.1.tgz",
+      "integrity": "sha512-rz1LklnlZ0yvVIt924yRGu+R87Fhfa06BdRIZR6GF6SXVSBTD9wCQmN6opXQLuSkoKXleWJwF3PW1ls8DGZjtw==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash.memoize": "^4.1.2"
+      }
+    },
+    "node_modules/@shinyoshiaki/jspack": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@shinyoshiaki/jspack/-/jspack-0.0.6.tgz",
+      "integrity": "sha512-SdsNhLjQh4onBlyPrn4ia1Pdx5bXT88G/LIEpOYAjx2u4xeY/m/HB5yHqlkJB1uQR3Zw4R3hBWLj46STRAN0rg=="
+    },
+    "node_modules/@types/node": {
+      "version": "10.17.60",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
+      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
+      "license": "MIT"
+    },
+    "node_modules/aes-js": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.1.2.tgz",
+      "integrity": "sha512-e5pEa2kBnBOgR4Y/p20pskXI74UEz7de8ZGVo58asOtvSVG5YAbJeELPZxOmt+Bnz3rX753YKhfIn4X4l1PPRQ==",
+      "license": "MIT"
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
       }
     },
     "node_modules/ansi-regex": {
@@ -79,6 +366,20 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/asn1js": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.10.tgz",
+      "integrity": "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "pvtsutils": "^1.3.6",
+        "pvutils": "^1.1.5",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/asynckit": {
@@ -161,6 +462,15 @@
         }
       ]
     },
+    "node_modules/big-integer": {
+      "version": "1.6.52",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
+      "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
+      "license": "Unlicense",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/buffer": {
       "version": "4.9.2",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
@@ -171,6 +481,21 @@
         "ieee754": "^1.1.4",
         "isarray": "^1.0.0"
       }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
+      "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
     },
     "node_modules/call-bind": {
       "version": "1.0.7",
@@ -220,6 +545,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
+      "license": "Apache-2.0"
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -267,10 +598,58 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
+    },
     "node_modules/crypto-js": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
       "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="
+    },
+    "node_modules/date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
     },
     "node_modules/default-user-agent": {
       "version": "1.0.0",
@@ -325,6 +704,18 @@
         "node": ">= 8.0.0"
       }
     },
+    "node_modules/dns-packet": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.6.1.tgz",
+      "integrity": "sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@leichtgewicht/ip-codec": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -345,6 +736,15 @@
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/es-define-property": {
@@ -399,6 +799,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.x"
+      }
+    },
+    "node_modules/ffmpeg-static": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/ffmpeg-static/-/ffmpeg-static-5.3.0.tgz",
+      "integrity": "sha512-H+K6sW6TiIX6VGend0KQwthe+kaceeH/luE8dIZyOP35ik7ahYojDuqlTV1bOrtEwl01sy2HFNGQfi5IDJvotg==",
+      "hasInstallScript": true,
+      "license": "GPL-3.0-or-later",
+      "dependencies": {
+        "@derhuerst/http-basic": "^8.2.0",
+        "env-paths": "^2.2.0",
+        "https-proxy-agent": "^5.0.0",
+        "progress": "^2.0.3"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/follow-redirects": {
@@ -492,6 +908,15 @@
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generate-function": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-property": "^1.0.2"
       }
     },
     "node_modules/get-intrinsic": {
@@ -607,6 +1032,28 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/http-response-object": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/http-response-object/-/http-response-object-3.0.2.tgz",
+      "integrity": "sha512-bqX0XTF6fnXSQcEJ2Iuyr75yVakyjIDCqroJQ/aHfSdlM743Cwqoi2nDYMzLGWUcuTWGWy8AAvOKXTfiv6q9RA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^10.0.3"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/ieee754": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
@@ -618,6 +1065,18 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/int64-buffer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/int64-buffer/-/int64-buffer-1.1.0.tgz",
+      "integrity": "sha512-94smTCQOvigN4d/2R/YDjz8YVG0Sufvv2aAh8P5m42gwhCsDAJqnbNOrxJsrADuAFAA69Q/ptGzxvNcNuIJcvw==",
+      "license": "MIT"
+    },
+    "node_modules/ip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
+      "integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ==",
+      "license": "MIT"
     },
     "node_modules/is-arguments": {
       "version": "1.1.1",
@@ -662,10 +1121,28 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "license": "MIT",
+      "dependencies": {
+        "isobject": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-promise": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
       "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ=="
+    },
+    "node_modules/is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
+      "license": "MIT"
     },
     "node_modules/is-typed-array": {
       "version": "1.1.13",
@@ -687,6 +1164,15 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "license": "MIT"
+    },
+    "node_modules/isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/jmespath": {
       "version": "0.16.0",
@@ -722,6 +1208,12 @@
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
       "license": "MIT"
     },
     "node_modules/lowdb": {
@@ -794,6 +1286,40 @@
         "node": "*"
       }
     },
+    "node_modules/mp4box": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/mp4box/-/mp4box-0.5.4.tgz",
+      "integrity": "sha512-GcCH0fySxBurJtvr0dfhz0IxHZjc1RP+F+I8xw+LIwkU1a+7HJx8NCDiww1I5u4Hz6g4eR1JlGADEGJ9r4lSfA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/multicast-dns": {
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.2.5.tgz",
+      "integrity": "sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg==",
+      "license": "MIT",
+      "dependencies": {
+        "dns-packet": "^5.2.2",
+        "thunky": "^1.0.2"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
+      }
+    },
+    "node_modules/nano-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/nano-time/-/nano-time-1.0.0.tgz",
+      "integrity": "sha512-flnngywOoQ0lLQOTRNexn2gGSNuM9bKj9RZAWSzhQ+UJYaAFG9bac4DW9VHjUAzrOaIcajHybCTHe/bkvozQqA==",
+      "license": "ISC",
+      "dependencies": {
+        "big-integer": "^1.6.16"
+      }
+    },
     "node_modules/node-domexception": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
@@ -861,6 +1387,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/p-cancelable": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+      "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/parse-cache-control": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
+      "integrity": "sha512-60zvsJReQPX5/QP0Kzfd/VrpjScIQ7SHBW6bFCYfEP+fp0Eppr1SHhIO5nd1PjZtvclzSzES9D/p5nFJurwfWg=="
+    },
     "node_modules/pause-stream": {
       "version": "0.0.11",
       "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
@@ -886,6 +1426,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -905,6 +1454,24 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
       "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==",
       "license": "MIT"
+    },
+    "node_modules/pvtsutils": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
+      "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/pvutils": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.5.tgz",
+      "integrity": "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
     },
     "node_modules/qs": {
       "version": "6.15.1",
@@ -930,6 +1497,26 @@
         "node": ">=0.4.x"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/reflect-metadata": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+      "license": "Apache-2.0"
+    },
     "node_modules/rotating-file-stream": {
       "version": "2.1.6",
       "resolved": "https://registry.npmjs.org/rotating-file-stream/-/rotating-file-stream-2.1.6.tgz",
@@ -940,6 +1527,31 @@
       "funding": {
         "url": "https://www.blockchain.com/btc/address/12p1p5q7sK75tPyuesZmssiMYr4TKzpSCN"
       }
+    },
+    "node_modules/rx.mini": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/rx.mini/-/rx.mini-1.4.0.tgz",
+      "integrity": "sha512-8w5cSc1mwNja7fl465DXOkVvIOkpvh2GW4jo31nAIvX4WTXCsRnKJGUfiDBzWtYRInEcHAUYIZfzusjIrea8gA=="
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/sax": {
       "version": "1.2.1",
@@ -1052,6 +1664,15 @@
         "graceful-fs": "^4.1.3"
       }
     },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -1078,6 +1699,57 @@
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
+    },
+    "node_modules/thunky": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
+      "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/tsyringe": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.10.0.tgz",
+      "integrity": "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/tsyringe/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
+    },
+    "node_modules/turbo-crc32": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/turbo-crc32/-/turbo-crc32-1.0.1.tgz",
+      "integrity": "sha512-8yyRd1ZdNp+AQLGqi3lTaA2k81JjlIZOyFQEsi7GQWBgirnQOxjqVtDEbYHM2Z4yFdJ5AQw0fxBLLnDCl6RXoQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tweetnacl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
+      "license": "Unlicense"
+    },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
     },
     "node_modules/undici": {
       "version": "5.29.0",
@@ -1156,6 +1828,12 @@
         "which-typed-array": "^1.1.2"
       }
     },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
     "node_modules/uuid": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
@@ -1180,6 +1858,177 @@
       "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/werift": {
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/werift/-/werift-0.20.1.tgz",
+      "integrity": "sha512-wZRIfTyvyC2c9daZ2udqkFkaH2cvIAoELeH5w2raBtODC7StILNjUFxgKs9msgn1g4IC3dkSKZo2ZyDDIJsrWA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fidm/x509": "^1.2.1",
+        "@minhducsun2002/leb128": "^1.0.0",
+        "@noble/curves": "^1.3.0",
+        "@peculiar/x509": "^1.9.2",
+        "@shinyoshiaki/binary-data": "^0.6.1",
+        "@shinyoshiaki/ebml-builder": "^0.0.1",
+        "@shinyoshiaki/jspack": "^0.0.6",
+        "aes-js": "^3.1.2",
+        "buffer-crc32": "^1.0.0",
+        "date-fns": "^2.29.3",
+        "debug": "^4.3.4",
+        "int64-buffer": "^1.0.1",
+        "ip": "^2.0.1",
+        "lodash": "^4.17.21",
+        "mp4box": "^0.5.2",
+        "nano-time": "^1.0.0",
+        "p-cancelable": "^2.1.1",
+        "rx.mini": "^1.2.2",
+        "turbo-crc32": "^1.0.1",
+        "tweetnacl": "^1.0.3",
+        "uuid": "^9.0.0",
+        "werift-common": "*",
+        "werift-dtls": "*",
+        "werift-ice": "*",
+        "werift-rtp": "*",
+        "werift-sctp": "*"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/werift-common": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/werift-common/-/werift-common-0.0.3.tgz",
+      "integrity": "sha512-ma3E4BqKTyZVLhrdfTVs2T1tg9seeUtKMRn5e64LwgrogWa62+3LAUoLBUSl1yPWhgSkXId7GmcHuWDen9IJeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shinyoshiaki/jspack": "^0.0.6",
+        "debug": "^4.4.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/werift-dtls": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/werift-dtls/-/werift-dtls-0.5.7.tgz",
+      "integrity": "sha512-z2fjbP7fFUFmu/Ky4bCKXzdgPTtmSY1DYi0TUf3GG2zJT4jMQ3TQmGY8y7BSSNGetvL4h3pRZ5un0EcSOWpPog==",
+      "license": "MIT",
+      "dependencies": {
+        "@fidm/x509": "^1.2.1",
+        "@noble/curves": "^1.3.0",
+        "@peculiar/x509": "^1.9.2",
+        "@shinyoshiaki/binary-data": "^0.6.1",
+        "date-fns": "^2.29.3",
+        "lodash": "^4.17.21",
+        "rx.mini": "^1.2.2",
+        "tweetnacl": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/werift-ice": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/werift-ice/-/werift-ice-0.2.2.tgz",
+      "integrity": "sha512-td52pHp+JmFnUn5jfDr/SSNO0dMCbknhuPdN1tFp9cfRj5jaktN63qnAdUuZC20QCC3ETWdsOthcm+RalHpFCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shinyoshiaki/jspack": "^0.0.6",
+        "buffer-crc32": "^1.0.0",
+        "debug": "^4.3.4",
+        "int64-buffer": "^1.0.1",
+        "ip": "^2.0.1",
+        "lodash": "^4.17.21",
+        "multicast-dns": "^7.2.5",
+        "p-cancelable": "^2.1.1",
+        "rx.mini": "^1.2.2"
+      }
+    },
+    "node_modules/werift-rtp": {
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/werift-rtp/-/werift-rtp-0.8.8.tgz",
+      "integrity": "sha512-GiYMSdvCyScQaw5bnEsraSoHUVZpjfokJAiLV4R1FsiB06t6XiebPYPpkqB9nYNNKiA8Z/cYWsym7wISq1sYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@minhducsun2002/leb128": "^1.0.0",
+        "@shinyoshiaki/jspack": "^0.0.6",
+        "aes-js": "^3.1.2",
+        "buffer": "^6.0.3",
+        "mp4box": "^0.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/werift-rtp/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/werift-rtp/node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/werift-sctp": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/werift-sctp/-/werift-sctp-0.0.11.tgz",
+      "integrity": "sha512-7109yuI5U7NTEHjqjn0A8VeynytkgVaxM6lRr1Ziv0D8bPcaB8A7U/P88M7WaCpWDoELHoXiRUjQycMWStIgjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shinyoshiaki/jspack": "^0.0.6"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/werift/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/which-typed-array": {
@@ -1217,6 +2066,27 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/xml2js": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
@@ -1249,10 +2119,197 @@
     }
   },
   "dependencies": {
+    "@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="
+    },
+    "@derhuerst/http-basic": {
+      "version": "8.2.4",
+      "resolved": "https://registry.npmjs.org/@derhuerst/http-basic/-/http-basic-8.2.4.tgz",
+      "integrity": "sha512-F9rL9k9Xjf5blCz8HsJRO4diy111cayL2vkY2XE4r4t3n0yPXVYy3KD3nJ1qbrSn9743UWSXH4IwuCa/HWlGFw==",
+      "requires": {
+        "caseless": "^0.12.0",
+        "concat-stream": "^2.0.0",
+        "http-response-object": "^3.0.1",
+        "parse-cache-control": "^1.0.1"
+      }
+    },
     "@fastify/busboy": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.0.tgz",
       "integrity": "sha512-+KpH+QxZU7O4675t3mnkQKcZZg56u+K/Ct2K+N2AZYNVK8kyeo/bI18tI8aPm3tvNNRyTWfj6s5tnGNlcbQRsA=="
+    },
+    "@fidm/asn1": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@fidm/asn1/-/asn1-1.0.4.tgz",
+      "integrity": "sha512-esd1jyNvRb2HVaQGq2Gg8Z0kbQPXzV9Tq5Z14KNIov6KfFD6PTaRIO8UpcsYiTNzOqJpmyzWgVTrUwFV3UF4TQ=="
+    },
+    "@fidm/x509": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@fidm/x509/-/x509-1.2.1.tgz",
+      "integrity": "sha512-nwc2iesjyc9hkuzcrMCBXQRn653XuAUKorfWM8PZyJawiy1QzLj4vahwzaI25+pfpwOLvMzbJ0uKpWLDNmo16w==",
+      "requires": {
+        "@fidm/asn1": "^1.0.4",
+        "tweetnacl": "^1.0.1"
+      }
+    },
+    "@leichtgewicht/ip-codec": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
+      "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw=="
+    },
+    "@minhducsun2002/leb128": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@minhducsun2002/leb128/-/leb128-1.0.0.tgz",
+      "integrity": "sha512-eFrYUPDVHeuwWHluTG1kwNQUEUcFjVKYwPkU8z9DR1JH3AW7JtJsG9cRVGmwz809kKtGfwGJj58juCZxEvnI/g=="
+    },
+    "@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "requires": {
+        "@noble/hashes": "1.8.0"
+      }
+    },
+    "@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="
+    },
+    "@peculiar/asn1-cms": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.6.1.tgz",
+      "integrity": "sha512-vdG4fBF6Lkirkcl53q6eOdn3XYKt+kJTG59edgRZORlg/3atWWEReRCx5rYE1ZzTTX6vLK5zDMjHh7vbrcXGtw==",
+      "requires": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "@peculiar/asn1-x509-attr": "^2.6.1",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "@peculiar/asn1-csr": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.6.1.tgz",
+      "integrity": "sha512-WRWnKfIocHyzFYQTka8O/tXCiBquAPSrRjXbOkHbO4qdmS6loffCEGs+rby6WxxGdJCuunnhS2duHURhjyio6w==",
+      "requires": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "@peculiar/asn1-ecc": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.6.1.tgz",
+      "integrity": "sha512-+Vqw8WFxrtDIN5ehUdvlN2m73exS2JVG0UAyfVB31gIfor3zWEAQPD+K9ydCxaj3MLen9k0JhKpu9LqviuCE1g==",
+      "requires": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "@peculiar/asn1-pfx": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.6.1.tgz",
+      "integrity": "sha512-nB5jVQy3MAAWvq0KY0R2JUZG8bO/bTLpnwyOzXyEh/e54ynGTatAR+csOnXkkVD9AFZ2uL8Z7EV918+qB1qDvw==",
+      "requires": {
+        "@peculiar/asn1-cms": "^2.6.1",
+        "@peculiar/asn1-pkcs8": "^2.6.1",
+        "@peculiar/asn1-rsa": "^2.6.1",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "@peculiar/asn1-pkcs8": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.6.1.tgz",
+      "integrity": "sha512-JB5iQ9Izn5yGMw3ZG4Nw3Xn/hb/G38GYF3lf7WmJb8JZUydhVGEjK/ZlFSWhnlB7K/4oqEs8HnfFIKklhR58Tw==",
+      "requires": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "@peculiar/asn1-pkcs9": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.6.1.tgz",
+      "integrity": "sha512-5EV8nZoMSxeWmcxWmmcolg22ojZRgJg+Y9MX2fnE2bGRo5KQLqV5IL9kdSQDZxlHz95tHvIq9F//bvL1OeNILw==",
+      "requires": {
+        "@peculiar/asn1-cms": "^2.6.1",
+        "@peculiar/asn1-pfx": "^2.6.1",
+        "@peculiar/asn1-pkcs8": "^2.6.1",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "@peculiar/asn1-x509-attr": "^2.6.1",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "@peculiar/asn1-rsa": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.6.1.tgz",
+      "integrity": "sha512-1nVMEh46SElUt5CB3RUTV4EG/z7iYc7EoaDY5ECwganibQPkZ/Y2eMsTKB/LeyrUJ+W/tKoD9WUqIy8vB+CEdA==",
+      "requires": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "@peculiar/asn1-schema": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.6.0.tgz",
+      "integrity": "sha512-xNLYLBFTBKkCzEZIw842BxytQQATQv+lDTCEMZ8C196iJcJJMBUZxrhSTxLaohMyKK8QlzRNTRkUmanucnDSqg==",
+      "requires": {
+        "asn1js": "^3.0.6",
+        "pvtsutils": "^1.3.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "@peculiar/asn1-x509": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.6.1.tgz",
+      "integrity": "sha512-O9jT5F1A2+t3r7C4VT7LYGXqkGLK7Kj1xFpz7U0isPrubwU5PbDoyYtx6MiGst29yq7pXN5vZbQFKRCP+lLZlA==",
+      "requires": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "asn1js": "^3.0.6",
+        "pvtsutils": "^1.3.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "@peculiar/asn1-x509-attr": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.6.1.tgz",
+      "integrity": "sha512-tlW6cxoHwgcQghnJwv3YS+9OO1737zgPogZ+CgWRUK4roEwIPzRH4JEiG770xe5HX2ATfCpmX60gurfWIF9dcQ==",
+      "requires": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "@peculiar/x509": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/x509/-/x509-1.14.3.tgz",
+      "integrity": "sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA==",
+      "requires": {
+        "@peculiar/asn1-cms": "^2.6.0",
+        "@peculiar/asn1-csr": "^2.6.0",
+        "@peculiar/asn1-ecc": "^2.6.0",
+        "@peculiar/asn1-pkcs9": "^2.6.0",
+        "@peculiar/asn1-rsa": "^2.6.0",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.0",
+        "pvtsutils": "^1.3.6",
+        "reflect-metadata": "^0.2.2",
+        "tslib": "^2.8.1",
+        "tsyringe": "^4.10.0"
+      }
     },
     "@ptkdev/logger": {
       "version": "1.8.0",
@@ -1266,6 +2323,46 @@
         "strip-ansi": "^6.0.0"
       }
     },
+    "@shinyoshiaki/binary-data": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@shinyoshiaki/binary-data/-/binary-data-0.6.1.tgz",
+      "integrity": "sha512-7HDb/fQAop2bCmvDIzU5+69i+UJaFgIVp99h1VzK1mpg1JwSODOkjbqD7ilTYnqlnadF8C4XjpwpepxDsGY6+w==",
+      "requires": {
+        "generate-function": "^2.3.1",
+        "is-plain-object": "^2.0.3"
+      }
+    },
+    "@shinyoshiaki/ebml-builder": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@shinyoshiaki/ebml-builder/-/ebml-builder-0.0.1.tgz",
+      "integrity": "sha512-rz1LklnlZ0yvVIt924yRGu+R87Fhfa06BdRIZR6GF6SXVSBTD9wCQmN6opXQLuSkoKXleWJwF3PW1ls8DGZjtw==",
+      "requires": {
+        "lodash.memoize": "^4.1.2"
+      }
+    },
+    "@shinyoshiaki/jspack": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@shinyoshiaki/jspack/-/jspack-0.0.6.tgz",
+      "integrity": "sha512-SdsNhLjQh4onBlyPrn4ia1Pdx5bXT88G/LIEpOYAjx2u4xeY/m/HB5yHqlkJB1uQR3Zw4R3hBWLj46STRAN0rg=="
+    },
+    "@types/node": {
+      "version": "10.17.60",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
+      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
+    },
+    "aes-js": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.1.2.tgz",
+      "integrity": "sha512-e5pEa2kBnBOgR4Y/p20pskXI74UEz7de8ZGVo58asOtvSVG5YAbJeELPZxOmt+Bnz3rX753YKhfIn4X4l1PPRQ=="
+    },
+    "agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "requires": {
+        "debug": "4"
+      }
+    },
     "ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -1277,6 +2374,16 @@
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "requires": {
         "color-convert": "^2.0.1"
+      }
+    },
+    "asn1js": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.10.tgz",
+      "integrity": "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==",
+      "requires": {
+        "pvtsutils": "^1.3.6",
+        "pvutils": "^1.1.5",
+        "tslib": "^2.8.1"
       }
     },
     "asynckit": {
@@ -1331,6 +2438,11 @@
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
+    "big-integer": {
+      "version": "1.6.52",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
+      "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg=="
+    },
     "buffer": {
       "version": "4.9.2",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
@@ -1340,6 +2452,16 @@
         "ieee754": "^1.1.4",
         "isarray": "^1.0.0"
       }
+    },
+    "buffer-crc32": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
+      "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w=="
+    },
+    "buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
     "call-bind": {
       "version": "1.0.7",
@@ -1370,6 +2492,11 @@
         "call-bind-apply-helpers": "^1.0.2",
         "get-intrinsic": "^1.3.0"
       }
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="
     },
     "chalk": {
       "version": "4.1.2",
@@ -1406,10 +2533,37 @@
         "delayed-stream": "~1.0.0"
       }
     },
+    "concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
+    },
     "crypto-js": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
       "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="
+    },
+    "date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "requires": {
+        "@babel/runtime": "^7.21.0"
+      }
+    },
+    "debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "requires": {
+        "ms": "^2.1.3"
+      }
     },
     "default-user-agent": {
       "version": "1.0.0",
@@ -1444,6 +2598,14 @@
       "resolved": "https://registry.npmjs.org/digest-header/-/digest-header-1.1.0.tgz",
       "integrity": "sha512-glXVh42vz40yZb9Cq2oMOt70FIoWiv+vxNvdKdU8CwjLad25qHM3trLxhl9bVjdr6WaslIXhWpn0NO8T/67Qjg=="
     },
+    "dns-packet": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.6.1.tgz",
+      "integrity": "sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==",
+      "requires": {
+        "@leichtgewicht/ip-codec": "^2.0.1"
+      }
+    },
     "dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -1461,6 +2623,11 @@
       "requires": {
         "once": "^1.4.0"
       }
+    },
+    "env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="
     },
     "es-define-property": {
       "version": "1.0.1",
@@ -1495,6 +2662,17 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
       "integrity": "sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw=="
+    },
+    "ffmpeg-static": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/ffmpeg-static/-/ffmpeg-static-5.3.0.tgz",
+      "integrity": "sha512-H+K6sW6TiIX6VGend0KQwthe+kaceeH/luE8dIZyOP35ik7ahYojDuqlTV1bOrtEwl01sy2HFNGQfi5IDJvotg==",
+      "requires": {
+        "@derhuerst/http-basic": "^8.2.0",
+        "env-paths": "^2.2.0",
+        "https-proxy-agent": "^5.0.0",
+        "progress": "^2.0.3"
+      }
     },
     "follow-redirects": {
       "version": "1.16.0",
@@ -1559,6 +2737,14 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
+    },
+    "generate-function": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+      "requires": {
+        "is-property": "^1.0.2"
+      }
     },
     "get-intrinsic": {
       "version": "1.3.0",
@@ -1630,6 +2816,23 @@
         "function-bind": "^1.1.2"
       }
     },
+    "http-response-object": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/http-response-object/-/http-response-object-3.0.2.tgz",
+      "integrity": "sha512-bqX0XTF6fnXSQcEJ2Iuyr75yVakyjIDCqroJQ/aHfSdlM743Cwqoi2nDYMzLGWUcuTWGWy8AAvOKXTfiv6q9RA==",
+      "requires": {
+        "@types/node": "^10.0.3"
+      }
+    },
+    "https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "requires": {
+        "agent-base": "6",
+        "debug": "4"
+      }
+    },
     "ieee754": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
@@ -1639,6 +2842,16 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "int64-buffer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/int64-buffer/-/int64-buffer-1.1.0.tgz",
+      "integrity": "sha512-94smTCQOvigN4d/2R/YDjz8YVG0Sufvv2aAh8P5m42gwhCsDAJqnbNOrxJsrADuAFAA69Q/ptGzxvNcNuIJcvw=="
+    },
+    "ip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
+      "integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ=="
     },
     "is-arguments": {
       "version": "1.1.1",
@@ -1662,10 +2875,23 @@
         "has-tostringtag": "^1.0.0"
       }
     },
+    "is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "requires": {
+        "isobject": "^3.0.1"
+      }
+    },
     "is-promise": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
       "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ=="
+    },
+    "is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g=="
     },
     "is-typed-array": {
       "version": "1.1.13",
@@ -1679,6 +2905,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+    },
+    "isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg=="
     },
     "jmespath": {
       "version": "0.16.0",
@@ -1708,6 +2939,11 @@
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="
+    },
+    "lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag=="
     },
     "lowdb": {
       "version": "1.0.0",
@@ -1754,6 +2990,33 @@
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
       "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
     },
+    "mp4box": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/mp4box/-/mp4box-0.5.4.tgz",
+      "integrity": "sha512-GcCH0fySxBurJtvr0dfhz0IxHZjc1RP+F+I8xw+LIwkU1a+7HJx8NCDiww1I5u4Hz6g4eR1JlGADEGJ9r4lSfA=="
+    },
+    "ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "multicast-dns": {
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.2.5.tgz",
+      "integrity": "sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg==",
+      "requires": {
+        "dns-packet": "^5.2.2",
+        "thunky": "^1.0.2"
+      }
+    },
+    "nano-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/nano-time/-/nano-time-1.0.0.tgz",
+      "integrity": "sha512-flnngywOoQ0lLQOTRNexn2gGSNuM9bKj9RZAWSzhQ+UJYaAFG9bac4DW9VHjUAzrOaIcajHybCTHe/bkvozQqA==",
+      "requires": {
+        "big-integer": "^1.6.16"
+      }
+    },
     "node-domexception": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
@@ -1789,6 +3052,16 @@
         "minimist": "^1.1.0"
       }
     },
+    "p-cancelable": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+      "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg=="
+    },
+    "parse-cache-control": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
+      "integrity": "sha512-60zvsJReQPX5/QP0Kzfd/VrpjScIQ7SHBW6bFCYfEP+fp0Eppr1SHhIO5nd1PjZtvclzSzES9D/p5nFJurwfWg=="
+    },
     "pause-stream": {
       "version": "0.0.11",
       "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
@@ -1806,6 +3079,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
       "integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q=="
+    },
+    "progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
     },
     "proxy-from-env": {
       "version": "1.1.0",
@@ -1826,6 +3104,19 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
       "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw=="
     },
+    "pvtsutils": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
+      "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
+      "requires": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "pvutils": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.5.tgz",
+      "integrity": "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA=="
+    },
     "qs": {
       "version": "6.15.1",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
@@ -1839,10 +3130,35 @@
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.1.tgz",
       "integrity": "sha512-wkvS7mL/JMugcup3/rMitHmd9ecIGd2lhFhK9N3UUQ450h66d1r3Y9nvXzQAW1Lq+wyx61k/1pfKS5KuKiyEbg=="
     },
+    "readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      }
+    },
+    "reflect-metadata": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q=="
+    },
     "rotating-file-stream": {
       "version": "2.1.6",
       "resolved": "https://registry.npmjs.org/rotating-file-stream/-/rotating-file-stream-2.1.6.tgz",
       "integrity": "sha512-qS0ndAlDu80MMXeRonqGMXslF0FErzcUSbcXhus3asRG4cvCS79hc5f7s0x4bPAsH6wAwyHVIeARg69VUe3JmQ=="
+    },
+    "rx.mini": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/rx.mini/-/rx.mini-1.4.0.tgz",
+      "integrity": "sha512-8w5cSc1mwNja7fl465DXOkVvIOkpvh2GW4jo31nAIvX4WTXCsRnKJGUfiDBzWtYRInEcHAUYIZfzusjIrea8gA=="
+    },
+    "safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
     },
     "sax": {
       "version": "1.2.1",
@@ -1919,6 +3235,14 @@
         "graceful-fs": "^4.1.3"
       }
     },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "requires": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -1939,6 +3263,46 @@
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
+    },
+    "thunky": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
+      "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA=="
+    },
+    "tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+    },
+    "tsyringe": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.10.0.tgz",
+      "integrity": "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==",
+      "requires": {
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "turbo-crc32": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/turbo-crc32/-/turbo-crc32-1.0.1.tgz",
+      "integrity": "sha512-8yyRd1ZdNp+AQLGqi3lTaA2k81JjlIZOyFQEsi7GQWBgirnQOxjqVtDEbYHM2Z4yFdJ5AQw0fxBLLnDCl6RXoQ=="
+    },
+    "tweetnacl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
     },
     "undici": {
       "version": "5.29.0",
@@ -2003,6 +3367,11 @@
         "which-typed-array": "^1.1.2"
       }
     },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
     "uuid": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
@@ -2021,6 +3390,122 @@
       "version": "4.0.0-beta.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
       "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug=="
+    },
+    "werift": {
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/werift/-/werift-0.20.1.tgz",
+      "integrity": "sha512-wZRIfTyvyC2c9daZ2udqkFkaH2cvIAoELeH5w2raBtODC7StILNjUFxgKs9msgn1g4IC3dkSKZo2ZyDDIJsrWA==",
+      "requires": {
+        "@fidm/x509": "^1.2.1",
+        "@minhducsun2002/leb128": "^1.0.0",
+        "@noble/curves": "^1.3.0",
+        "@peculiar/x509": "^1.9.2",
+        "@shinyoshiaki/binary-data": "^0.6.1",
+        "@shinyoshiaki/ebml-builder": "^0.0.1",
+        "@shinyoshiaki/jspack": "^0.0.6",
+        "aes-js": "^3.1.2",
+        "buffer-crc32": "^1.0.0",
+        "date-fns": "^2.29.3",
+        "debug": "^4.3.4",
+        "int64-buffer": "^1.0.1",
+        "ip": "^2.0.1",
+        "lodash": "^4.17.21",
+        "mp4box": "^0.5.2",
+        "nano-time": "^1.0.0",
+        "p-cancelable": "^2.1.1",
+        "rx.mini": "^1.2.2",
+        "turbo-crc32": "^1.0.1",
+        "tweetnacl": "^1.0.3",
+        "uuid": "^9.0.0",
+        "werift-common": "*",
+        "werift-dtls": "*",
+        "werift-ice": "*",
+        "werift-rtp": "*",
+        "werift-sctp": "*"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+          "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
+        }
+      }
+    },
+    "werift-common": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/werift-common/-/werift-common-0.0.3.tgz",
+      "integrity": "sha512-ma3E4BqKTyZVLhrdfTVs2T1tg9seeUtKMRn5e64LwgrogWa62+3LAUoLBUSl1yPWhgSkXId7GmcHuWDen9IJeQ==",
+      "requires": {
+        "@shinyoshiaki/jspack": "^0.0.6",
+        "debug": "^4.4.0"
+      }
+    },
+    "werift-dtls": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/werift-dtls/-/werift-dtls-0.5.7.tgz",
+      "integrity": "sha512-z2fjbP7fFUFmu/Ky4bCKXzdgPTtmSY1DYi0TUf3GG2zJT4jMQ3TQmGY8y7BSSNGetvL4h3pRZ5un0EcSOWpPog==",
+      "requires": {
+        "@fidm/x509": "^1.2.1",
+        "@noble/curves": "^1.3.0",
+        "@peculiar/x509": "^1.9.2",
+        "@shinyoshiaki/binary-data": "^0.6.1",
+        "date-fns": "^2.29.3",
+        "lodash": "^4.17.21",
+        "rx.mini": "^1.2.2",
+        "tweetnacl": "^1.0.3"
+      }
+    },
+    "werift-ice": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/werift-ice/-/werift-ice-0.2.2.tgz",
+      "integrity": "sha512-td52pHp+JmFnUn5jfDr/SSNO0dMCbknhuPdN1tFp9cfRj5jaktN63qnAdUuZC20QCC3ETWdsOthcm+RalHpFCQ==",
+      "requires": {
+        "@shinyoshiaki/jspack": "^0.0.6",
+        "buffer-crc32": "^1.0.0",
+        "debug": "^4.3.4",
+        "int64-buffer": "^1.0.1",
+        "ip": "^2.0.1",
+        "lodash": "^4.17.21",
+        "multicast-dns": "^7.2.5",
+        "p-cancelable": "^2.1.1",
+        "rx.mini": "^1.2.2"
+      }
+    },
+    "werift-rtp": {
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/werift-rtp/-/werift-rtp-0.8.8.tgz",
+      "integrity": "sha512-GiYMSdvCyScQaw5bnEsraSoHUVZpjfokJAiLV4R1FsiB06t6XiebPYPpkqB9nYNNKiA8Z/cYWsym7wISq1sYSQ==",
+      "requires": {
+        "@minhducsun2002/leb128": "^1.0.0",
+        "@shinyoshiaki/jspack": "^0.0.6",
+        "aes-js": "^3.1.2",
+        "buffer": "^6.0.3",
+        "mp4box": "^0.5.3"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.2.1"
+          }
+        },
+        "ieee754": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+          "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+        }
+      }
+    },
+    "werift-sctp": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/werift-sctp/-/werift-sctp-0.0.11.tgz",
+      "integrity": "sha512-7109yuI5U7NTEHjqjn0A8VeynytkgVaxM6lRr1Ziv0D8bPcaB8A7U/P88M7WaCpWDoELHoXiRUjQycMWStIgjQ==",
+      "requires": {
+        "@shinyoshiaki/jspack": "^0.0.6"
+      }
     },
     "which-typed-array": {
       "version": "1.1.15",
@@ -2046,6 +3531,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
+    "ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "requires": {}
     },
     "xml2js": {
       "version": "0.6.2",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "wyze-api",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "description": "An unoficial API wrapper for Wyze products.",
   "homepage": "https://github.com/jfarmer08/wyze-api",
   "main": "./src/index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test --test-reporter=spec tests/*.test.js"
   },
   "keywords": [
     "wyze",
@@ -21,17 +21,20 @@
   "author": "Allen Farmer",
   "license": "MIT",
   "dependencies": {
-    "axios": "1.7.4",
-    "moment": "2.29.4",
-    "urllib": "3.18.0",
-    "crypto-js": "4.2.0",
-    "utf8": "3.0.0",
-    "colorsys": "^1.0.22",
-    "base64-js": "1.5.1",
-    "querystring": "0.2.1",
-    "uuid-by-string": "4.0.0",
     "@ptkdev/logger": "1.8.0",
-    "aws-sdk": "2.1678.0"
+    "aws-sdk": "2.1678.0",
+    "axios": "1.7.4",
+    "base64-js": "1.5.1",
+    "colorsys": "^1.0.22",
+    "crypto-js": "4.2.0",
+    "ffmpeg-static": "^5.3.0",
+    "moment": "2.29.4",
+    "querystring": "0.2.1",
+    "urllib": "3.18.0",
+    "utf8": "3.0.0",
+    "uuid-by-string": "4.0.0",
+    "werift": "^0.20.1",
+    "ws": "^8.20.0"
   },
   "funding": [
     {

--- a/src/cameraStreamCapture.js
+++ b/src/cameraStreamCapture.js
@@ -1,0 +1,272 @@
+/**
+ * Headless WebRTC frame capture.
+ *
+ * Negotiates a WebRTC session against a Wyze camera using its Kinesis Video
+ * signaling URL, receives the H.264 RTP stream via werift, forwards the
+ * packets to a local UDP socket, and pipes that into FFmpeg to extract a
+ * single JPEG frame.
+ *
+ * The ffmpeg binary is provided by the `ffmpeg-static` npm package — no
+ * system install needed. Falls back to `ffmpeg` on PATH if ffmpeg-static
+ * fails to resolve (e.g., unsupported platform).
+ */
+
+const dgram = require("dgram");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const nodeCrypto = require("crypto");
+const { spawn } = require("child_process");
+const WebSocket = require("ws");
+const { RTCPeerConnection, RTCRtpCodecParameters } = require("werift");
+
+// Wyze cameras stream H.264. werift's default codec preferences include
+// VP8/VP9, which Wyze rejects — the SDP answer ends up empty and werift
+// throws "negotiate codecs failed". Pin H.264 (baseline 3.1, the profile
+// every Wyze cam supports) and matching feedback.
+const H264_CODECS = [
+  new RTCRtpCodecParameters({
+    mimeType: "video/H264",
+    clockRate: 90000,
+    rtcpFeedback: [
+      { type: "nack" },
+      { type: "nack", parameter: "pli" },
+      { type: "goog-remb" },
+    ],
+    parameters:
+      "level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42001f",
+  }),
+];
+
+let _ffmpegBinaryPath = null;
+function _resolveFfmpegPath() {
+  if (_ffmpegBinaryPath) return _ffmpegBinaryPath;
+  try {
+    const ffmpegStatic = require("ffmpeg-static");
+    if (ffmpegStatic && fs.existsSync(ffmpegStatic)) {
+      _ffmpegBinaryPath = ffmpegStatic;
+      return _ffmpegBinaryPath;
+    }
+  } catch (_) { /* fall through */ }
+  _ffmpegBinaryPath = "ffmpeg";
+  return _ffmpegBinaryPath;
+}
+
+/**
+ * Bind a UDP socket on a random free port on 127.0.0.1, then close it and
+ * return the port. There's a tiny race window before FFmpeg binds the same
+ * port — acceptable for a local-only socket.
+ */
+async function _pickFreeUdpPort() {
+  return new Promise((resolve, reject) => {
+    const sock = dgram.createSocket("udp4");
+    sock.once("error", reject);
+    sock.bind(0, "127.0.0.1", () => {
+      const { port } = sock.address();
+      sock.close(() => resolve(port));
+    });
+  });
+}
+
+function _writeSdpFile(rtpPort) {
+  const sdp = `v=0
+o=- 0 0 IN IP4 127.0.0.1
+s=WyzeCapture
+c=IN IP4 127.0.0.1
+t=0 0
+m=video ${rtpPort} RTP/AVP 96
+a=rtpmap:96 H264/90000
+a=fmtp:96 packetization-mode=1
+`;
+  const sdpPath = path.join(
+    os.tmpdir(),
+    `wyze-capture-${process.pid}-${nodeCrypto.randomBytes(4).toString("hex")}.sdp`
+  );
+  fs.writeFileSync(sdpPath, sdp);
+  return sdpPath;
+}
+
+function _spawnFfmpeg(sdpPath) {
+  return spawn(_resolveFfmpegPath(), [
+    "-loglevel", "error",
+    "-protocol_whitelist", "file,rtp,udp",
+    "-fflags", "+genpts+discardcorrupt+nobuffer",
+    "-flags", "low_delay",
+    "-i", sdpPath,
+    "-frames:v", "1",
+    "-vsync", "passthrough",
+    "-f", "image2",
+    "-c:v", "mjpeg",
+    "-q:v", "2",
+    "pipe:1",
+  ], { stdio: ["ignore", "pipe", "pipe"] });
+}
+
+/**
+ * Send a signaling message in the format the Wyze/Kinesis WebRTC service
+ * expects: a JSON envelope with base64-encoded inner payload.
+ */
+function _sendSignal(ws, action, payload, recipientClientId = "MASTER") {
+  if (ws.readyState !== WebSocket.OPEN) return;
+  ws.send(JSON.stringify({
+    action,
+    messagePayload: Buffer.from(JSON.stringify(payload)).toString("base64"),
+    recipientClientId,
+  }));
+}
+
+function _parseSignalMessage(raw) {
+  if (typeof raw !== "string" || raw.length === 0) return null;
+  try {
+    const env = JSON.parse(raw);
+    const type = env.messageType || env.action;
+    if (!type) return null;
+    let payload = null;
+    if (env.messagePayload) {
+      try {
+        payload = JSON.parse(Buffer.from(env.messagePayload, "base64").toString("utf8"));
+      } catch (_) { /* keep null */ }
+    }
+    return { type, payload };
+  } catch (_) {
+    return null;
+  }
+}
+
+/**
+ * Capture a single JPEG frame from a Wyze camera's WebRTC stream.
+ *
+ * @param {Object} params
+ * @param {string} params.signalingUrl — Kinesis Video signaling URL (signed)
+ * @param {Array<{urls:string, username?:string, credential?:string}>} params.iceServers
+ * @param {Object} [params.logger] — optional logger with .debug/.warning/.error
+ * @param {number} [params.timeoutMs=20000] — overall timeout
+ * @returns {Promise<Buffer>} JPEG image bytes
+ */
+async function captureStreamFrame({
+  signalingUrl,
+  iceServers,
+  logger = null,
+  timeoutMs = 20_000,
+}) {
+  const log = (level, msg) => {
+    if (!logger) return;
+    if (typeof logger[level] === "function") logger[level](`[capture] ${msg}`);
+  };
+
+  const rtpPort = await _pickFreeUdpPort();
+  const sdpPath = _writeSdpFile(rtpPort);
+
+  let ffmpeg = null;
+  let pc = null;
+  let ws = null;
+  let fwdSock = null;
+  const cleanup = () => {
+    try { ws?.close(); } catch (_) {}
+    try { pc?.close(); } catch (_) {}
+    try { fwdSock?.close(); } catch (_) {}
+    try { ffmpeg?.kill("SIGKILL"); } catch (_) {}
+    try { fs.unlinkSync(sdpPath); } catch (_) {}
+  };
+
+  try {
+    ffmpeg = _spawnFfmpeg(sdpPath);
+    fwdSock = dgram.createSocket("udp4");
+
+    const stdoutChunks = [];
+    const stderrChunks = [];
+    ffmpeg.stdout.on("data", (chunk) => stdoutChunks.push(chunk));
+    ffmpeg.stderr.on("data", (chunk) => stderrChunks.push(chunk));
+
+    // Attach error/close handlers immediately so spawn failures (ENOENT,
+    // crashes) reject the outcome promise instead of going unhandled and
+    // crashing the Node process.
+    const ffmpegOutcome = new Promise((resolve, reject) => {
+      ffmpeg.once("error", (err) => {
+        if (err && err.code === "ENOENT") {
+          reject(new Error(
+            `ffmpeg binary not found (tried: ${_resolveFfmpegPath()}). ` +
+            "Re-run `npm install` to fetch the bundled ffmpeg via ffmpeg-static, " +
+            "or install ffmpeg on your system PATH if your platform isn't supported."
+          ));
+        } else {
+          reject(err);
+        }
+      });
+      ffmpeg.once("close", (code) => {
+        if (stdoutChunks.length > 0) resolve(Buffer.concat(stdoutChunks));
+        else reject(new Error(`ffmpeg exited (${code}) without producing a frame: ${Buffer.concat(stderrChunks).toString()}`));
+      });
+    });
+
+    pc = new RTCPeerConnection({
+      iceServers,
+      codecs: { video: H264_CODECS },
+    });
+    pc.addTransceiver("video", { direction: "recvonly" });
+
+    pc.onTrack.subscribe((track) => {
+      log("debug", `track received kind=${track.kind} codec=${track.codec?.name}`);
+      track.onReceiveRtp.subscribe((rtp) => {
+        try {
+          fwdSock.send(rtp.serialize(), rtpPort, "127.0.0.1");
+        } catch (_) { /* socket may be closed */ }
+      });
+    });
+
+    ws = new WebSocket(signalingUrl);
+    const remoteAnswered = new Promise((resolve, reject) => {
+      const onMsg = async (raw) => {
+        const msg = _parseSignalMessage(raw.toString());
+        if (!msg) return;
+        try {
+          if (msg.type === "SDP_ANSWER") {
+            await pc.setRemoteDescription(msg.payload);
+            log("debug", "applied SDP_ANSWER");
+            resolve();
+          } else if (msg.type === "ICE_CANDIDATE") {
+            await pc.addIceCandidate(msg.payload);
+          }
+        } catch (err) {
+          reject(err);
+        }
+      };
+      ws.on("message", onMsg);
+      ws.once("error", reject);
+      ws.once("close", (code) => {
+        if (code !== 1000) reject(new Error(`signaling WS closed (${code})`));
+      });
+    });
+
+    const timeout = new Promise((_, reject) =>
+      setTimeout(() => reject(new Error(`capture timed out after ${timeoutMs}ms`)), timeoutMs)
+    );
+
+    await Promise.race([
+      new Promise((resolve, reject) => {
+        ws.once("open", resolve);
+        ws.once("error", reject);
+      }),
+      ffmpegOutcome,  // fail fast if ffmpeg dies (e.g. ENOENT) instead of hanging on WS open
+      timeout,
+    ]);
+    log("debug", "signaling open, sending offer");
+    const offer = await pc.createOffer();
+    await pc.setLocalDescription(offer);
+    _sendSignal(ws, "SDP_OFFER", { type: "offer", sdp: pc.localDescription.sdp });
+
+    pc.onIceCandidate.subscribe((c) => {
+      if (c?.candidate) _sendSignal(ws, "ICE_CANDIDATE", c);
+    });
+
+    await Promise.race([remoteAnswered, ffmpegOutcome, timeout]);
+    log("debug", "WebRTC negotiation complete, waiting for frame");
+    const buffer = await Promise.race([ffmpegOutcome, timeout]);
+    log("debug", `captured ${buffer.length} bytes`);
+    return buffer;
+  } finally {
+    cleanup();
+  }
+}
+
+module.exports = { captureStreamFrame };

--- a/src/constants.js
+++ b/src/constants.js
@@ -6,6 +6,12 @@ module.exports = Object.freeze({
   fordAppSecret: "4deekof1ba311c5c33a9cb8e12787e8c", // Required for Locks
   oliveSigningSecret: "wyze_app_secret_key_132", // Required for the thermostat
   oliveAppId: "9319141212m2ik", // Required for the thermostat
+  webSigningSecret: "gbJojEBViLklgwyyDikx5ztSvKBXI5oU", // Required for camera WebRTC stream info
+  webAppId: "strv_e7f78e9e7738dc50", // Required for camera WebRTC stream info
+  webAppInfo: "wyze_web_2.3.1", // Required for camera WebRTC stream info
+
+  // Wyze response codes (from wyzeapy types.py ResponseCodes enum)
+  deviceOfflineCode: "3019",
 
   // Application Information (for emulation)
   appInfo: "wyze_android_2.19.14", // Required for the thermostat

--- a/src/crypto.js
+++ b/src/crypto.js
@@ -88,6 +88,24 @@ function iot3CreateSignature(bodyStr, access_token) {
     return crypto.createHmac("md5", secret).update(bodyStr).digest("hex");
 }
 
+function web_create_signature(payload, access_token) {
+    let body
+
+    if (typeof payload === "object") {
+        body = Object.keys(payload)
+            .sort()
+            .map(key => `${key}=${payload[key]}`)
+            .join("&")
+    } else {
+        body = payload
+    }
+
+    const access_key = `${access_token}${constants.webSigningSecret}`
+    const secret = crypto.createHash("md5").update(access_key).digest("hex")
+
+    return crypto.createHmac("md5", secret).update(body).digest("hex")
+}
+
 module.exports = {
     fordCreateSignature,
     oliveCreateSignatureSingle,
@@ -95,4 +113,5 @@ module.exports = {
     olive_create_signature,
     ford_create_signature,
     iot3CreateSignature,
+    web_create_signature,
 }

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ const crypto = require("./crypto");
 const constants = require("./constants");
 const util = require("./util");
 const RokuAuthLib = require("./rokuAuth")
+const cameraStreamCapture = require("./cameraStreamCapture");
 
 module.exports = class WyzeAPI {
   constructor(options) {
@@ -1980,6 +1981,553 @@ module.exports = class WyzeAPI {
   }
 
   /**
+   * Fetch the WebRTC stream info for a camera. Returns a Kinesis Video
+   * signaling URL plus ICE/STUN/TURN servers — the credentials needed to
+   * negotiate a live WebRTC stream. Does not return a playable URL on its
+   * own; a WebRTC client (e.g. werift, go2rtc) is required to consume it.
+   * @param {string} deviceMac
+   * @param {string} deviceModel
+   * @param {Object} [options]
+   * @param {boolean} [options.substream=false] — request the lower-bitrate sub stream (experimental; depends on camera support)
+   * @returns {Promise<{signaling_url: string, ice_servers: Array<{url: string, username: string, credential: string}>}>}
+   */
+  async cameraGetStreamInfo(deviceMac, deviceModel, options = {}) {
+    await this.maybeLogin();
+
+    const parameters = { use_trickle: true };
+    if (options.substream) parameters.sub_stream = true;
+
+    const payload = {
+      device_list: [
+        {
+          device_id: deviceMac,
+          device_model: deviceModel,
+          provider: "webrtc",
+          parameters,
+        },
+      ],
+      nonce: String(Date.now()),
+    };
+    const body = JSON.stringify(payload);
+    const signature = crypto.web_create_signature(body, this.access_token);
+
+    const headers = {
+      "Accept-Encoding": "gzip",
+      appId: constants.webAppId,
+      appInfo: constants.webAppInfo,
+      access_token: this.access_token,
+      Authorization: this.access_token,
+      signature2: signature,
+      requestid: String(Date.now() % 100000),
+      "Content-Type": "application/json; charset=utf-8",
+    };
+
+    const url = `${constants.iot3BaseUrl}/app/v4/camera/get-streams`;
+    if (this.apiLogEnabled) {
+      this.log.info(`Performing request: ${url}`);
+    }
+    try {
+      const response = await axios.post(url, body, { headers });
+      // Honor X-RateLimit-Remaining: sleeps if dangerously low. Won't throw.
+      await this._checkRateLimit(response.headers);
+
+      const data = response.data;
+      if (this.apiLogEnabled) {
+        this.log.info(`API response cameraGetStreamInfo: ${JSON.stringify(data)}`);
+      }
+
+      const code = data?.code;
+      const errorMessage = data?.msg || data?.description || "";
+
+      if (typeof code !== "undefined" && Number(code) !== 1) {
+        if (this._isAccessTokenError(code, errorMessage)) {
+          await this._handleAccessTokenError(response, errorMessage, code, url, body);
+          throw new Error(
+            `Wyze access token error (${code}): ${errorMessage}. Token has been refreshed; retry the call.`
+          );
+        }
+        if (this._isRateLimitError(code, errorMessage)) {
+          throw new Error(`Wyze API rate limited (${code}): ${errorMessage}`);
+        }
+        if (String(code) === constants.deviceOfflineCode) {
+          throw new Error(`Camera is offline: ${JSON.stringify(data)}`);
+        }
+        throw new Error(`Wyze API Error (${code}) - ${errorMessage}`);
+      }
+
+      if (!Array.isArray(data.data) || data.data.length !== 1) {
+        throw new Error(`Unexpected response from cameraGetStreamInfo: ${JSON.stringify(data)}`);
+      }
+
+      const entry = data.data[0];
+      if (!entry.property) {
+        throw new Error(`Unexpected response from cameraGetStreamInfo: ${JSON.stringify(entry)}`);
+      }
+      if (entry.property["iot-device::iot-state"] !== 1) {
+        throw new Error(`Camera is offline: ${JSON.stringify(entry)}`);
+      }
+      if (entry.property["iot-device::iot-power"] !== 1) {
+        throw new Error(`Camera is off: ${JSON.stringify(entry)}`);
+      }
+      return entry.params;
+    } catch (error) {
+      this.log.error(`Request failed: ${error.message}`);
+      if (error.response) {
+        this.log.error(`Response cameraGetStreamInfo (${error.response.status} - ${error.response.statusText}): ${JSON.stringify(error.response.data, null, 2)}`);
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Convenience: return only the Kinesis Video WebRTC signaling URL.
+   * @param {string} deviceMac
+   * @param {string} deviceModel
+   * @returns {Promise<string>}
+   */
+  async cameraGetSignalingUrl(deviceMac, deviceModel, options = {}) {
+    const info = await this.cameraGetStreamInfo(deviceMac, deviceModel, options);
+    return info.signaling_url;
+  }
+
+  /**
+   * Convenience: return only the ICE/STUN/TURN server list for WebRTC negotiation.
+   * @param {string} deviceMac
+   * @param {string} deviceModel
+   * @returns {Promise<Array<{url: string, username: string, credential: string}>>}
+   */
+  async cameraGetIceServers(deviceMac, deviceModel, options = {}) {
+    const info = await this.cameraGetStreamInfo(deviceMac, deviceModel, options);
+    return info.ice_servers;
+  }
+
+  // Camera helpers — pure (sync, operate on a device object)
+
+  /**
+   * @param {Object} device
+   * @returns {boolean}
+   */
+  cameraIsOnline(device) {
+    // Wyze's get_device_list reports online state under different fields
+    // depending on device type and API version. Check the known ones in
+    // priority order; first defined wins.
+    if (device?.conn_state !== undefined) return device.conn_state === 1;
+    if (device?.device_params?.status !== undefined) return device.device_params.status === 1;
+    if (device?.is_online !== undefined) return Boolean(device.is_online);
+    return false;
+  }
+
+  /**
+   * @param {Object} device
+   * @returns {string|null}
+   */
+  cameraGetThumbnail(device) {
+    const thumbnails = device?.device_params?.camera_thumbnails;
+    if (Array.isArray(thumbnails) && thumbnails.length > 0) {
+      return thumbnails[0]?.url ?? null;
+    }
+    return null;
+  }
+
+  /**
+   * @param {Object} device
+   * @returns {Object|null}
+   */
+  cameraGetSnapshot(device) {
+    const thumbnails = device?.device_params?.camera_thumbnails;
+    if (Array.isArray(thumbnails) && thumbnails.length > 0) {
+      return thumbnails[0] ?? null;
+    }
+    return null;
+  }
+
+  /**
+   * @param {Object} device
+   * @returns {{mac: string, productModel: string, nickname: string, online: boolean, thumbnail: string|null}}
+   */
+  cameraToSummary(device) {
+    return {
+      mac: device?.mac,
+      productModel: device?.product_model,
+      nickname: device?.nickname,
+      online: this.cameraIsOnline(device),
+      thumbnail: this.cameraGetThumbnail(device),
+    };
+  }
+
+  // Camera helpers — lookup (async)
+
+  async getCameras() {
+    return this.getDevicesByType("Camera");
+  }
+
+  async getOnlineCameras() {
+    const cameras = await this.getCameras();
+    return cameras.filter((camera) => this.cameraIsOnline(camera));
+  }
+
+  /**
+   * Look up a single camera by MAC address.
+   * @param {string} mac
+   * @returns {Promise<Object|undefined>}
+   */
+  async getCamera(mac) {
+    const cameras = await this.getCameras();
+    return cameras.find((camera) => camera.mac === mac);
+  }
+
+  async getCameraSnapshot(mac) {
+    const camera = await this.getCamera(mac);
+    return camera ? this.cameraGetSnapshot(camera) : null;
+  }
+
+  async getCameraSnapshotUrl(mac) {
+    const snapshot = await this.getCameraSnapshot(mac);
+    return snapshot?.url ?? null;
+  }
+
+  async getCameraSummaries() {
+    const cameras = await this.getCameras();
+    return cameras.map((device) => this.cameraToSummary(device));
+  }
+
+  /**
+   * Capture a single JPEG frame by negotiating a headless WebRTC session
+   * with the camera. Requires `ffmpeg` on the system PATH.
+   *
+   * Results are cached per-mac for `cacheTtlMs` (default 10s) so that rapid
+   * repeat callers (e.g., multiple HomeKit accessories) share one capture.
+   *
+   * @param {string} deviceMac
+   * @param {string} deviceModel
+   * @param {Object} [options]
+   * @param {number} [options.timeoutMs=20000] — overall timeout for negotiation + frame
+   * @param {boolean} [options.noCache=false] — bypass and overwrite the per-mac cache
+   * @param {number} [options.cacheTtlMs=10000]
+   * @returns {Promise<Buffer>} JPEG bytes
+   */
+  async cameraCaptureSnapshot(deviceMac, deviceModel, options = {}) {
+    const { timeoutMs = 20_000, noCache = false, cacheTtlMs = 10_000 } = options;
+
+    if (!this._snapshotCaptureCache) this._snapshotCaptureCache = new Map();
+    if (!noCache) {
+      const entry = this._snapshotCaptureCache.get(deviceMac);
+      if (entry && entry.expiresAt > Date.now()) return entry.buffer;
+    }
+
+    const conn = await this.getCameraWebRTCConnectionInfo(deviceMac, deviceModel, {
+      noCache: true,
+      includeClientId: false,
+    });
+
+    const buffer = await cameraStreamCapture.captureStreamFrame({
+      signalingUrl: conn.signalingUrl,
+      iceServers: conn.iceServers,
+      logger: this.apiLogEnabled ? this.log : null,
+      timeoutMs,
+    });
+
+    if (!noCache) {
+      this._snapshotCaptureCache.set(deviceMac, {
+        buffer,
+        expiresAt: Date.now() + cacheTtlMs,
+      });
+    }
+    return buffer;
+  }
+
+  /**
+   * Get a JPEG image for a camera. Tries the cloud thumbnail first; if
+   * unavailable or the download fails, falls back to a live WebRTC capture
+   * via {@link cameraCaptureSnapshot}.
+   *
+   * @param {string} mac
+   * @param {Object} [options]
+   * @param {boolean} [options.skipCloud=false] — go straight to live capture
+   * @param {number} [options.timeoutMs] — forwarded to capture
+   * @param {boolean} [options.noCache=false] — forwarded to capture
+   * @returns {Promise<{buffer: Buffer, source: "cloud"|"capture"}>}
+   */
+  async getCameraSnapshotImage(mac, options = {}) {
+    if (!options.skipCloud) {
+      const cloud = await this.getCameraSnapshot(mac);
+      if (cloud?.url) {
+        try {
+          const resp = await axios.get(cloud.url, { responseType: "arraybuffer" });
+          return { buffer: Buffer.from(resp.data), source: "cloud" };
+        } catch (err) {
+          this.log.warning(`Cloud snapshot fetch failed, falling back to capture: ${err.message}`);
+        }
+      }
+    }
+
+    const camera = await this.getCamera(mac);
+    if (!camera) throw new Error(`Camera not found: ${mac}`);
+    const buffer = await this.cameraCaptureSnapshot(camera.mac, camera.product_model, options);
+    return { buffer, source: "capture" };
+  }
+
+  /**
+   * Look up a single camera by nickname (case-insensitive).
+   * @param {string} nickname
+   * @returns {Promise<Object|undefined>}
+   */
+  async getCameraByName(nickname) {
+    const cameras = await this.getCameras();
+    return cameras.find(
+      (camera) => camera?.nickname?.toLowerCase() === nickname?.toLowerCase()
+    );
+  }
+
+  async getOfflineCameras() {
+    const cameras = await this.getCameras();
+    return cameras.filter((camera) => !this.cameraIsOnline(camera));
+  }
+
+  // Camera helpers — device-info accessors
+
+  cameraGetSignalStrength(device) {
+    return device?.device_params?.signal_strength ?? null;
+  }
+
+  cameraGetIp(device) {
+    return device?.device_params?.ip ?? null;
+  }
+
+  cameraGetFirmware(device) {
+    return device?.firmware_ver ?? null;
+  }
+
+  cameraGetTimezone(device) {
+    return device?.timezone_name ?? null;
+  }
+
+  cameraGetLastSeen(device) {
+    const ts = device?.device_params?.last_login_time;
+    return typeof ts === "number" ? new Date(ts) : null;
+  }
+
+  // Camera helpers — stream connection
+
+  /**
+   * Generate a unique client identifier for tracking a viewer's WebRTC
+   * session against a camera. Useful for log correlation, for client-side
+   * bookkeeping that distinguishes concurrent viewers, and for injection
+   * into a Kinesis Video signaling URL via {@link setCameraSignalingClientId}.
+   * @param {string|Object} deviceOrMac — a device object or MAC string
+   * @param {string} [prefix="viewer"]
+   * @returns {string}
+   */
+  createCameraStreamClientId(deviceOrMac, prefix = "viewer") {
+    const mac = typeof deviceOrMac === "string" ? deviceOrMac : deviceOrMac?.mac;
+    const safePrefix = String(prefix || "viewer").replace(/[^a-zA-Z0-9_-]/g, "-");
+    const macSlug =
+      (mac || "camera").replace(/[^a-zA-Z0-9]/g, "").slice(-8).toLowerCase() || "camera";
+    const random = nodeCrypto.randomBytes(4).toString("hex");
+    return `${safePrefix}-${macSlug}-${Date.now()}-${random}`;
+  }
+
+  /**
+   * Decode double-encoded Kinesis Video signaling URLs (Wyze occasionally
+   * returns `%25` where `%` is intended). Idempotent on already-decoded URLs.
+   * @param {string} signalingUrl
+   * @returns {string}
+   */
+  normalizeCameraSignalingUrl(signalingUrl) {
+    if (!signalingUrl || typeof signalingUrl !== "string") return signalingUrl;
+    if (signalingUrl.includes("%25")) {
+      try {
+        return decodeURIComponent(signalingUrl);
+      } catch (_) {
+        return signalingUrl;
+      }
+    }
+    return signalingUrl;
+  }
+
+  /**
+   * Convert Wyze's `{url, username, credential}` ICE entries into the
+   * `{urls, ...}` shape expected by `RTCPeerConnection`. Drops malformed
+   * entries (missing `url`).
+   * @param {Array<{url: string, username?: string, credential?: string}>} iceServers
+   * @returns {Array<{urls: string, username?: string, credential?: string}>}
+   */
+  sanitizeCameraIceServers(iceServers = []) {
+    return iceServers
+      .map((server) => {
+        if (!server || !server.url) return null;
+        const out = { urls: server.url };
+        if (server.username) out.username = server.username;
+        if (server.credential) out.credential = server.credential;
+        return out;
+      })
+      .filter(Boolean);
+  }
+
+  /**
+   * Parse online/power state from a raw {@link cameraGetStreamInfo} response
+   * without throwing. Returns null on malformed input.
+   * @param {Object} streamInfoResponse
+   * @returns {{online: boolean, powered: boolean}|null}
+   */
+  parseCameraStatus(streamInfoResponse) {
+    try {
+      const item = streamInfoResponse?.data?.[0];
+      if (!item?.property) return null;
+      return {
+        online: item.property["iot-device::iot-state"] === 1,
+        powered: item.property["iot-device::iot-power"] === 1,
+      };
+    } catch (_) {
+      return null;
+    }
+  }
+
+  /**
+   * Bundle everything a WebRTC client needs to start a session with a camera:
+   * the signed signaling URL (returned untouched — Wyze pre-signs it with
+   * AWS SigV4), sanitized ICE servers (in the `{urls,...}` shape
+   * `RTCPeerConnection` expects), and the `auth_token` from the API. Also
+   * generates a client ID for app-side tracking; this is NOT injected into
+   * the URL.
+   *
+   * Results are cached per (mac, model, substream) for {@link options.cacheTtlMs}
+   * (default 60s) to avoid hammering the API on rapid reconnects. Pass
+   * `noCache: true` to bypass.
+   *
+   * @param {string} deviceMac
+   * @param {string} deviceModel
+   * @param {Object} [options]
+   * @param {boolean} [options.substream=false] — request the lower-bitrate sub stream
+   * @param {boolean} [options.includeClientId=true] — generate (or accept) a client ID in the result
+   * @param {string} [options.clientId] — caller-supplied client ID (overrides generation)
+   * @param {string} [options.clientIdPrefix="viewer"] — prefix when generating a client ID
+   * @param {boolean} [options.noCache=false] — bypass the in-memory cache
+   * @param {number} [options.cacheTtlMs=60000] — cache TTL when caching is enabled
+   * @returns {Promise<{signalingUrl: string, iceServers: Array<Object>, authToken: string|null, clientId?: string, mac: string, model: string, substream: boolean, cached: boolean}>}
+   */
+  _streamCacheKey(deviceMac, deviceModel, substream) {
+    return `${deviceMac}:${deviceModel}:${substream ? "sub" : "main"}`;
+  }
+
+  async getCameraWebRTCConnectionInfo(deviceMac, deviceModel, options = {}) {
+    const {
+      substream = false,
+      includeClientId = true,
+      clientId,
+      clientIdPrefix = "viewer",
+      noCache = false,
+      cacheTtlMs = 60_000,
+    } = options;
+
+    if (!this._streamInfoCache) this._streamInfoCache = new Map();
+    const cacheKey = this._streamCacheKey(deviceMac, deviceModel, substream);
+    let bundle;
+    let cached = false;
+
+    if (!noCache) {
+      const entry = this._streamInfoCache.get(cacheKey);
+      if (entry && entry.expiresAt > Date.now()) {
+        bundle = entry.bundle;
+        cached = true;
+      }
+    }
+
+    if (!bundle) {
+      const info = await this.cameraGetStreamInfo(deviceMac, deviceModel, { substream });
+      bundle = {
+        signalingUrl: this.normalizeCameraSignalingUrl(info.signaling_url),
+        iceServers: this.sanitizeCameraIceServers(info.ice_servers),
+        authToken: info.auth_token ?? null,
+      };
+      if (!noCache) {
+        this._streamInfoCache.set(cacheKey, {
+          bundle,
+          expiresAt: Date.now() + cacheTtlMs,
+        });
+      }
+    }
+
+    const result = {
+      ...bundle,
+      mac: deviceMac,
+      model: deviceModel,
+      substream,
+      cached,
+    };
+
+    if (includeClientId) {
+      result.clientId =
+        clientId || this.createCameraStreamClientId(deviceMac, clientIdPrefix);
+    }
+
+    return result;
+  }
+
+  /**
+   * Like {@link getCameraWebRTCConnectionInfo} but retries with exponential
+   * backoff on transient failures.
+   * @param {string} deviceMac
+   * @param {string} deviceModel
+   * @param {Object} [options] — forwarded to {@link getCameraWebRTCConnectionInfo}
+   * @param {Object} [retryOptions]
+   * @param {number} [retryOptions.maxAttempts=3]
+   * @param {number} [retryOptions.baseDelayMs=2000]
+   * @param {Function} [retryOptions.onRetry] — called as `(attempt, error)` before each retry
+   * @returns {Promise<Object>}
+   */
+  async getCameraWebRTCConnectionInfoWithReconnect(
+    deviceMac,
+    deviceModel,
+    options = {},
+    retryOptions = {}
+  ) {
+    return this.cameraStreamWithReconnect(
+      () => this.getCameraWebRTCConnectionInfo(deviceMac, deviceModel, options),
+      retryOptions
+    );
+  }
+
+  /**
+   * Wrap any async stream-related call with exponential-backoff retry.
+   * @param {Function} fn
+   * @param {Object} [options]
+   * @param {number} [options.maxAttempts=3]
+   * @param {number} [options.baseDelayMs=2000]
+   * @param {Function} [options.onRetry]
+   */
+  async cameraStreamWithReconnect(fn, { maxAttempts = 3, baseDelayMs = 2000, onRetry } = {}) {
+    let attempt = 0;
+    while (true) {
+      try {
+        return await fn();
+      } catch (err) {
+        attempt += 1;
+        if (attempt >= maxAttempts) throw err;
+        if (onRetry) onRetry(attempt, err);
+        const delay = baseDelayMs * Math.pow(2, attempt - 1);
+        await new Promise((resolve) => setTimeout(resolve, delay));
+      }
+    }
+  }
+
+  /**
+   * Clear the in-memory stream-info cache. Pass a MAC to clear just one camera,
+   * or omit to clear all.
+   * @param {string} [deviceMac]
+   */
+  clearCameraStreamCache(deviceMac) {
+    if (!this._streamInfoCache) return;
+    if (!deviceMac) {
+      this._streamInfoCache.clear();
+      return;
+    }
+    for (const key of this._streamInfoCache.keys()) {
+      if (key.startsWith(`${deviceMac}:`)) this._streamInfoCache.delete(key);
+    }
+  }
+
+  /**
    * Turn Plug 0 = off or 1 = on
    * @param {string} deviceMac
    * @param {string} deviceModel
@@ -2452,3 +3000,16 @@ module.exports = class WyzeAPI {
   }
 
 };
+
+/**
+ * Camera stream lifecycle states. Numeric values mirror docker-wyze-bridge's
+ * StreamStatus so they can be used interchangeably with that ecosystem.
+ */
+module.exports.StreamStatus = Object.freeze({
+  OFFLINE: -90,
+  STOPPING: -1,
+  DISABLED: 0,
+  STOPPED: 1,
+  CONNECTING: 2,
+  CONNECTED: 3,
+});

--- a/tests/camera-helpers.test.js
+++ b/tests/camera-helpers.test.js
@@ -1,0 +1,136 @@
+/**
+ * Pure helpers on the WyzeAPI prototype — no network, no auth.
+ */
+const test = require("node:test");
+const assert = require("node:assert");
+const WyzeAPI = require("../src/index");
+
+const stub = () => Object.create(WyzeAPI.prototype);
+
+test("cameraIsOnline", async (t) => {
+  const w = stub();
+
+  await t.test("conn_state takes priority", () => {
+    assert.strictEqual(w.cameraIsOnline({ conn_state: 1 }), true);
+    assert.strictEqual(w.cameraIsOnline({ conn_state: 0 }), false);
+    // device_params.status is ignored when conn_state is present
+    assert.strictEqual(
+      w.cameraIsOnline({ conn_state: 1, device_params: { status: 0 } }),
+      true
+    );
+  });
+
+  await t.test("device_params.status fallback when no conn_state", () => {
+    assert.strictEqual(w.cameraIsOnline({ device_params: { status: 1 } }), true);
+    assert.strictEqual(w.cameraIsOnline({ device_params: { status: 0 } }), false);
+  });
+
+  await t.test("is_online final fallback", () => {
+    assert.strictEqual(w.cameraIsOnline({ is_online: true }), true);
+    assert.strictEqual(w.cameraIsOnline({ is_online: false }), false);
+  });
+
+  await t.test("returns false for empty / null / undefined", () => {
+    assert.strictEqual(w.cameraIsOnline({}), false);
+    assert.strictEqual(w.cameraIsOnline(null), false);
+    assert.strictEqual(w.cameraIsOnline(undefined), false);
+  });
+});
+
+test("cameraGetThumbnail", async (t) => {
+  const w = stub();
+
+  await t.test("returns first thumbnail URL", () => {
+    assert.strictEqual(
+      w.cameraGetThumbnail({
+        device_params: { camera_thumbnails: [{ url: "https://a" }, { url: "https://b" }] },
+      }),
+      "https://a"
+    );
+  });
+
+  await t.test("returns null when no thumbnails", () => {
+    assert.strictEqual(w.cameraGetThumbnail({ device_params: {} }), null);
+    assert.strictEqual(
+      w.cameraGetThumbnail({ device_params: { camera_thumbnails: [] } }),
+      null
+    );
+    assert.strictEqual(w.cameraGetThumbnail({}), null);
+    assert.strictEqual(w.cameraGetThumbnail(null), null);
+  });
+});
+
+test("cameraGetSnapshot returns full thumbnail object", () => {
+  const w = stub();
+  const thumb = { url: "https://x", ts: 1700000000, type: 1 };
+  assert.deepStrictEqual(
+    w.cameraGetSnapshot({ device_params: { camera_thumbnails: [thumb] } }),
+    thumb
+  );
+  assert.strictEqual(w.cameraGetSnapshot({}), null);
+});
+
+test("cameraToSummary builds correct shape", () => {
+  const w = stub();
+  const device = {
+    mac: "AA:BB:CC",
+    product_model: "WYZE_CAKP",
+    nickname: "Front",
+    conn_state: 1,
+    device_params: {
+      camera_thumbnails: [{ url: "https://thumb" }],
+    },
+  };
+  assert.deepStrictEqual(w.cameraToSummary(device), {
+    mac: "AA:BB:CC",
+    productModel: "WYZE_CAKP",
+    nickname: "Front",
+    online: true,
+    thumbnail: "https://thumb",
+  });
+});
+
+test("device-info accessors", async (t) => {
+  const w = stub();
+  const camera = {
+    firmware_ver: "4.50.4.182",
+    timezone_name: "America/New_York",
+    device_params: {
+      signal_strength: 67,
+      ip: "192.168.1.5",
+      last_login_time: 1700000000000,
+    },
+  };
+
+  await t.test("cameraGetSignalStrength", () => {
+    assert.strictEqual(w.cameraGetSignalStrength(camera), 67);
+    assert.strictEqual(w.cameraGetSignalStrength({}), null);
+    assert.strictEqual(w.cameraGetSignalStrength(null), null);
+  });
+
+  await t.test("cameraGetIp", () => {
+    assert.strictEqual(w.cameraGetIp(camera), "192.168.1.5");
+    assert.strictEqual(w.cameraGetIp({}), null);
+  });
+
+  await t.test("cameraGetFirmware reads top-level field", () => {
+    assert.strictEqual(w.cameraGetFirmware(camera), "4.50.4.182");
+    assert.strictEqual(w.cameraGetFirmware({}), null);
+  });
+
+  await t.test("cameraGetTimezone reads top-level field", () => {
+    assert.strictEqual(w.cameraGetTimezone(camera), "America/New_York");
+    assert.strictEqual(w.cameraGetTimezone({}), null);
+  });
+
+  await t.test("cameraGetLastSeen returns Date or null", () => {
+    const d = w.cameraGetLastSeen(camera);
+    assert.ok(d instanceof Date);
+    assert.strictEqual(d.getTime(), 1700000000000);
+    assert.strictEqual(w.cameraGetLastSeen({}), null);
+    assert.strictEqual(
+      w.cameraGetLastSeen({ device_params: { last_login_time: "not a number" } }),
+      null
+    );
+  });
+});

--- a/tests/camera-lookup.test.js
+++ b/tests/camera-lookup.test.js
@@ -1,0 +1,126 @@
+/**
+ * Lookup helpers — getCameras / getCamera / snapshots / summaries.
+ * Stubs `getDeviceList` on a prototype-based instance so no network calls.
+ */
+const test = require("node:test");
+const assert = require("node:assert");
+const WyzeAPI = require("../src/index");
+
+function stubWith(devices) {
+  const w = Object.create(WyzeAPI.prototype);
+  w.getDeviceList = async () => devices;
+  return w;
+}
+
+const DEVICES = [
+  {
+    mac: "CAM1",
+    product_type: "Camera",
+    product_model: "WYZE_CAKP",
+    nickname: "Front Porch",
+    conn_state: 1,
+    device_params: {
+      camera_thumbnails: [{ url: "https://thumb/cam1.jpg", ts: 100 }],
+      ip: "192.168.1.10",
+    },
+  },
+  {
+    mac: "CAM2",
+    product_type: "camera", // case-insensitive match
+    product_model: "WYZEDB3",
+    nickname: "Doorbell",
+    conn_state: 0,
+    device_params: {},
+  },
+  {
+    mac: "BULB1",
+    product_type: "Light",
+    product_model: "WLPA19",
+    nickname: "Lamp",
+  },
+  {
+    mac: "PLUG1",
+    product_type: "Plug",
+    product_model: "WLPP1",
+    nickname: "Outlet",
+  },
+];
+
+test("getCameras filters by product_type === 'Camera' (case-insensitive)", async () => {
+  const w = stubWith(DEVICES);
+  const cameras = await w.getCameras();
+  assert.deepStrictEqual(
+    cameras.map((c) => c.mac),
+    ["CAM1", "CAM2"]
+  );
+});
+
+test("getOnlineCameras / getOfflineCameras", async () => {
+  const w = stubWith(DEVICES);
+  const online = await w.getOnlineCameras();
+  const offline = await w.getOfflineCameras();
+  assert.deepStrictEqual(online.map((c) => c.mac), ["CAM1"]);
+  assert.deepStrictEqual(offline.map((c) => c.mac), ["CAM2"]);
+});
+
+test("getCamera returns by MAC, undefined when missing", async () => {
+  const w = stubWith(DEVICES);
+  const cam = await w.getCamera("CAM1");
+  assert.strictEqual(cam.nickname, "Front Porch");
+  assert.strictEqual(await w.getCamera("DOES_NOT_EXIST"), undefined);
+  // Non-cameras are not in the result set even if mac matches
+  assert.strictEqual(await w.getCamera("BULB1"), undefined);
+});
+
+test("getCameraByName matches case-insensitively", async () => {
+  const w = stubWith(DEVICES);
+  assert.strictEqual((await w.getCameraByName("Front Porch")).mac, "CAM1");
+  assert.strictEqual((await w.getCameraByName("FRONT PORCH")).mac, "CAM1");
+  assert.strictEqual((await w.getCameraByName("front porch")).mac, "CAM1");
+  assert.strictEqual(await w.getCameraByName("nope"), undefined);
+});
+
+test("getCameraSnapshot returns first thumbnail object", async () => {
+  const w = stubWith(DEVICES);
+  const snap = await w.getCameraSnapshot("CAM1");
+  assert.deepStrictEqual(snap, { url: "https://thumb/cam1.jpg", ts: 100 });
+});
+
+test("getCameraSnapshot returns null when no thumbnails", async () => {
+  const w = stubWith(DEVICES);
+  assert.strictEqual(await w.getCameraSnapshot("CAM2"), null);
+});
+
+test("getCameraSnapshot returns null when camera not found", async () => {
+  const w = stubWith(DEVICES);
+  assert.strictEqual(await w.getCameraSnapshot("MISSING"), null);
+});
+
+test("getCameraSnapshotUrl pulls just the URL", async () => {
+  const w = stubWith(DEVICES);
+  assert.strictEqual(
+    await w.getCameraSnapshotUrl("CAM1"),
+    "https://thumb/cam1.jpg"
+  );
+  assert.strictEqual(await w.getCameraSnapshotUrl("CAM2"), null);
+});
+
+test("getCameraSummaries returns one summary per camera", async () => {
+  const w = stubWith(DEVICES);
+  const summaries = await w.getCameraSummaries();
+  assert.strictEqual(summaries.length, 2);
+  assert.deepStrictEqual(summaries[0], {
+    mac: "CAM1",
+    productModel: "WYZE_CAKP",
+    nickname: "Front Porch",
+    online: true,
+    thumbnail: "https://thumb/cam1.jpg",
+  });
+  assert.deepStrictEqual(summaries[1], {
+    mac: "CAM2",
+    productModel: "WYZEDB3",
+    nickname: "Doorbell",
+    online: false,
+    thumbnail: null,
+  });
+});

--- a/tests/camera-stream.test.js
+++ b/tests/camera-stream.test.js
@@ -1,0 +1,386 @@
+/**
+ * Stream-related helpers: URL/ICE/status normalization, client-ID generation,
+ * cache key, signature determinism, and the cache behavior of
+ * getCameraWebRTCConnectionInfo (with cameraGetStreamInfo stubbed out).
+ */
+const test = require("node:test");
+const assert = require("node:assert");
+const WyzeAPI = require("../src/index");
+const cryptoHelpers = require("../src/crypto");
+
+const stub = () => Object.create(WyzeAPI.prototype);
+
+test("normalizeCameraSignalingUrl", async (t) => {
+  const w = stub();
+
+  await t.test("decodes one pass of percent-encoding when %25 is present", () => {
+    // The helper only does a single decodeURIComponent pass — `%253D` (a
+    // double-encoded `=`) becomes `%3D` (single-encoded), which is what
+    // URL parsers handle natively. We don't want to fully unescape and
+    // break a legitimately-encoded query string.
+    assert.strictEqual(
+      w.normalizeCameraSignalingUrl("wss://example.com/?a%253Db"),
+      "wss://example.com/?a%3Db"
+    );
+  });
+
+  await t.test("leaves single-encoded URLs alone", () => {
+    const url = "wss://example.com/?a=b&c=d";
+    assert.strictEqual(w.normalizeCameraSignalingUrl(url), url);
+  });
+
+  await t.test("handles empty / null", () => {
+    assert.strictEqual(w.normalizeCameraSignalingUrl(""), "");
+    assert.strictEqual(w.normalizeCameraSignalingUrl(null), null);
+    assert.strictEqual(w.normalizeCameraSignalingUrl(undefined), undefined);
+  });
+});
+
+test("sanitizeCameraIceServers", async (t) => {
+  const w = stub();
+
+  await t.test("renames `url` to `urls` and preserves credentials", () => {
+    assert.deepStrictEqual(
+      w.sanitizeCameraIceServers([
+        { url: "turn:foo:443", username: "u", credential: "c" },
+        { url: "stun:bar:443" },
+      ]),
+      [
+        { urls: "turn:foo:443", username: "u", credential: "c" },
+        { urls: "stun:bar:443" },
+      ]
+    );
+  });
+
+  await t.test("drops malformed entries", () => {
+    assert.deepStrictEqual(
+      w.sanitizeCameraIceServers([
+        { url: "" },
+        null,
+        undefined,
+        { username: "no-url" },
+        { url: "stun:keep" },
+      ]),
+      [{ urls: "stun:keep" }]
+    );
+  });
+
+  await t.test("returns empty array for empty/missing input", () => {
+    assert.deepStrictEqual(w.sanitizeCameraIceServers([]), []);
+    assert.deepStrictEqual(w.sanitizeCameraIceServers(), []);
+  });
+
+  await t.test("omits empty username/credential", () => {
+    assert.deepStrictEqual(
+      w.sanitizeCameraIceServers([{ url: "stun:x", username: "", credential: "" }]),
+      [{ urls: "stun:x" }]
+    );
+  });
+});
+
+test("parseCameraStatus", async (t) => {
+  const w = stub();
+
+  await t.test("returns online/powered for well-formed response", () => {
+    assert.deepStrictEqual(
+      w.parseCameraStatus({
+        data: [
+          { property: { "iot-device::iot-state": 1, "iot-device::iot-power": 1 } },
+        ],
+      }),
+      { online: true, powered: true }
+    );
+  });
+
+  await t.test("flags offline / off correctly", () => {
+    assert.deepStrictEqual(
+      w.parseCameraStatus({
+        data: [
+          { property: { "iot-device::iot-state": 0, "iot-device::iot-power": 1 } },
+        ],
+      }),
+      { online: false, powered: true }
+    );
+    assert.deepStrictEqual(
+      w.parseCameraStatus({
+        data: [
+          { property: { "iot-device::iot-state": 1, "iot-device::iot-power": 0 } },
+        ],
+      }),
+      { online: true, powered: false }
+    );
+  });
+
+  await t.test("returns null for malformed input", () => {
+    assert.strictEqual(w.parseCameraStatus(null), null);
+    assert.strictEqual(w.parseCameraStatus({}), null);
+    assert.strictEqual(w.parseCameraStatus({ data: [] }), null);
+    assert.strictEqual(w.parseCameraStatus({ data: [{}] }), null);
+  });
+});
+
+test("createCameraStreamClientId", async (t) => {
+  const w = stub();
+
+  await t.test("uses last 8 chars of MAC, lowercased, alphanum-only", () => {
+    const id = w.createCameraStreamClientId("AA:BB:CC:DD:EE:FF", "test");
+    assert.match(id, /^test-ccddeeff-\d+-[a-f0-9]{8}$/);
+  });
+
+  await t.test("accepts a device object", () => {
+    const id = w.createCameraStreamClientId({ mac: "AA:BB:CC:DD:EE:FF" });
+    assert.match(id, /^viewer-ccddeeff-\d+-[a-f0-9]{8}$/);
+  });
+
+  await t.test("falls back to 'camera' slug when mac missing", () => {
+    const id = w.createCameraStreamClientId(null);
+    assert.match(id, /^viewer-camera-\d+-[a-f0-9]{8}$/);
+  });
+
+  await t.test("sanitizes prefix", () => {
+    const id = w.createCameraStreamClientId("AA", "ho me/bridge");
+    assert.match(id, /^ho-me-bridge-/);
+  });
+
+  await t.test("two consecutive ids differ", () => {
+    const a = w.createCameraStreamClientId("AA");
+    const b = w.createCameraStreamClientId("AA");
+    assert.notStrictEqual(a, b);
+  });
+});
+
+test("_streamCacheKey format is stable", () => {
+  const w = stub();
+  assert.strictEqual(
+    w._streamCacheKey("AA:BB", "WYZE_CAKP", false),
+    "AA:BB:WYZE_CAKP:main"
+  );
+  assert.strictEqual(
+    w._streamCacheKey("AA:BB", "WYZE_CAKP", true),
+    "AA:BB:WYZE_CAKP:sub"
+  );
+});
+
+test("web_create_signature is deterministic", () => {
+  // Reference value computed from the equivalent Python implementation
+  // (wyzeapy PR #230). If the algorithm changes, this catches it.
+  assert.strictEqual(
+    cryptoHelpers.web_create_signature("identical_body_for_test", "fake_token"),
+    "f28a8dbc5a38670bcbc26ac82c6b9a99"
+  );
+});
+
+test("web_create_signature handles object payload via sorted form-encoding", () => {
+  // Object input is serialized as sorted "k=v&k=v" — this exercises the
+  // non-string branch of the helper.
+  const sig = cryptoHelpers.web_create_signature({ b: 2, a: 1 }, "token");
+  // Same input, deterministic output
+  assert.strictEqual(
+    sig,
+    cryptoHelpers.web_create_signature({ a: 1, b: 2 }, "token")
+  );
+});
+
+test("getCameraWebRTCConnectionInfo: cache + sanitization", async (t) => {
+  const baseInfo = {
+    signaling_url: "wss://kvs/?a%253Db",
+    ice_servers: [
+      { url: "turn:foo:443", username: "u", credential: "c" },
+      { url: "stun:bar:443" },
+    ],
+    auth_token: "TOKEN",
+  };
+
+  await t.test("first call fetches; second call (within TTL) is cached", async () => {
+    const w = stub();
+    let calls = 0;
+    w.cameraGetStreamInfo = async () => {
+      calls += 1;
+      return baseInfo;
+    };
+
+    const r1 = await w.getCameraWebRTCConnectionInfo("AA", "MODEL");
+    assert.strictEqual(calls, 1);
+    assert.strictEqual(r1.cached, false);
+
+    const r2 = await w.getCameraWebRTCConnectionInfo("AA", "MODEL");
+    assert.strictEqual(calls, 1, "second call should hit cache");
+    assert.strictEqual(r2.cached, true);
+  });
+
+  await t.test("noCache: true bypasses cache", async () => {
+    const w = stub();
+    let calls = 0;
+    w.cameraGetStreamInfo = async () => {
+      calls += 1;
+      return baseInfo;
+    };
+
+    await w.getCameraWebRTCConnectionInfo("AA", "MODEL");
+    await w.getCameraWebRTCConnectionInfo("AA", "MODEL", { noCache: true });
+    assert.strictEqual(calls, 2);
+  });
+
+  await t.test("substream uses a separate cache slot", async () => {
+    const w = stub();
+    let calls = 0;
+    w.cameraGetStreamInfo = async () => {
+      calls += 1;
+      return baseInfo;
+    };
+
+    await w.getCameraWebRTCConnectionInfo("AA", "MODEL");
+    await w.getCameraWebRTCConnectionInfo("AA", "MODEL", { substream: true });
+    assert.strictEqual(calls, 2, "main and sub streams cache separately");
+  });
+
+  await t.test("sanitizes ICE, normalizes URL, exposes authToken", async () => {
+    const w = stub();
+    w.cameraGetStreamInfo = async () => baseInfo;
+
+    const r = await w.getCameraWebRTCConnectionInfo("AA", "MODEL");
+    assert.strictEqual(r.signalingUrl, "wss://kvs/?a%3Db", "URL decoded one pass");
+    assert.deepStrictEqual(r.iceServers, [
+      { urls: "turn:foo:443", username: "u", credential: "c" },
+      { urls: "stun:bar:443" },
+    ]);
+    assert.strictEqual(r.authToken, "TOKEN");
+    assert.strictEqual(r.mac, "AA");
+    assert.strictEqual(r.model, "MODEL");
+    assert.strictEqual(r.substream, false);
+    // Default includeClientId=true
+    assert.match(r.clientId, /^viewer-/);
+  });
+
+  await t.test("includeClientId: false omits clientId", async () => {
+    const w = stub();
+    w.cameraGetStreamInfo = async () => baseInfo;
+
+    const r = await w.getCameraWebRTCConnectionInfo("AA", "MODEL", {
+      includeClientId: false,
+    });
+    assert.strictEqual(r.clientId, undefined);
+  });
+
+  await t.test("does NOT modify signed signalingUrl by default", async () => {
+    // Critical regression test: we previously injected X-Amz-ClientId into
+    // the signed URL, which broke the AWS SigV4 signature and caused
+    // WebSocket close 1006. The URL must come back unchanged from the
+    // sanitization step.
+    const w = stub();
+    w.cameraGetStreamInfo = async () => ({
+      signaling_url: "wss://kvs/?X-Amz-ClientId=ORIGINAL&X-Amz-Signature=sig",
+      ice_servers: [],
+      auth_token: null,
+    });
+
+    const r = await w.getCameraWebRTCConnectionInfo("AA", "MODEL");
+    assert.strictEqual(
+      r.signalingUrl,
+      "wss://kvs/?X-Amz-ClientId=ORIGINAL&X-Amz-Signature=sig"
+    );
+  });
+});
+
+test("clearCameraStreamCache", async (t) => {
+  await t.test("clears one mac, leaves others", async () => {
+    const w = stub();
+    let calls = 0;
+    w.cameraGetStreamInfo = async () => {
+      calls += 1;
+      return { signaling_url: "wss://x", ice_servers: [], auth_token: null };
+    };
+
+    await w.getCameraWebRTCConnectionInfo("AA", "MODEL");
+    await w.getCameraWebRTCConnectionInfo("BB", "MODEL");
+    assert.strictEqual(calls, 2);
+
+    w.clearCameraStreamCache("AA");
+
+    await w.getCameraWebRTCConnectionInfo("AA", "MODEL");
+    assert.strictEqual(calls, 3, "AA refetched after clear");
+    await w.getCameraWebRTCConnectionInfo("BB", "MODEL");
+    assert.strictEqual(calls, 3, "BB still cached");
+  });
+
+  await t.test("clears everything when called without args", async () => {
+    const w = stub();
+    let calls = 0;
+    w.cameraGetStreamInfo = async () => {
+      calls += 1;
+      return { signaling_url: "wss://x", ice_servers: [], auth_token: null };
+    };
+
+    await w.getCameraWebRTCConnectionInfo("AA", "MODEL");
+    await w.getCameraWebRTCConnectionInfo("BB", "MODEL");
+    w.clearCameraStreamCache();
+    await w.getCameraWebRTCConnectionInfo("AA", "MODEL");
+    await w.getCameraWebRTCConnectionInfo("BB", "MODEL");
+    assert.strictEqual(calls, 4);
+  });
+});
+
+test("cameraStreamWithReconnect retries with exponential backoff", async (t) => {
+  await t.test("succeeds on first try", async () => {
+    const w = stub();
+    let calls = 0;
+    const result = await w.cameraStreamWithReconnect(async () => {
+      calls += 1;
+      return "ok";
+    });
+    assert.strictEqual(result, "ok");
+    assert.strictEqual(calls, 1);
+  });
+
+  await t.test("retries up to maxAttempts then throws", async () => {
+    const w = stub();
+    let calls = 0;
+    const onRetry = [];
+    await assert.rejects(
+      w.cameraStreamWithReconnect(
+        async () => {
+          calls += 1;
+          throw new Error("boom");
+        },
+        {
+          maxAttempts: 3,
+          baseDelayMs: 1,
+          onRetry: (n, e) => onRetry.push([n, e.message]),
+        }
+      ),
+      /boom/
+    );
+    assert.strictEqual(calls, 3);
+    assert.strictEqual(onRetry.length, 2); // called between attempts, not after final
+  });
+
+  await t.test("succeeds after a transient failure", async () => {
+    const w = stub();
+    let calls = 0;
+    const result = await w.cameraStreamWithReconnect(
+      async () => {
+        calls += 1;
+        if (calls === 1) throw new Error("transient");
+        return "ok";
+      },
+      { maxAttempts: 3, baseDelayMs: 1 }
+    );
+    assert.strictEqual(result, "ok");
+    assert.strictEqual(calls, 2);
+  });
+});
+
+test("WyzeAPI.StreamStatus exports lifecycle constants and is frozen", () => {
+  assert.deepStrictEqual(WyzeAPI.StreamStatus, {
+    OFFLINE: -90,
+    STOPPING: -1,
+    DISABLED: 0,
+    STOPPED: 1,
+    CONNECTING: 2,
+    CONNECTED: 3,
+  });
+  assert.ok(
+    Object.isFrozen(WyzeAPI.StreamStatus),
+    "StreamStatus must be frozen so consumers can't accidentally mutate it"
+  );
+});

--- a/wiki/Browser-Viewer-Example.md
+++ b/wiki/Browser-Viewer-Example.md
@@ -1,0 +1,57 @@
+# Browser Viewer Example
+
+A minimal HTTP server + browser UI that lists your cameras, plays live WebRTC streams, and grabs snapshots — built on the camera helpers documented in [Camera Streaming](Camera-Streaming.md).
+
+## Run it
+
+```bash
+git clone https://github.com/jfarmer08/wyze-api.git
+cd wyze-api/example
+npm install
+cp .env.example .env
+# Edit .env with your Wyze credentials
+npm run viewer
+# → http://localhost:3030
+```
+
+By default the viewer runs on **port 3030**. Override with `VIEWER_PORT=8080 npm run viewer` or set `VIEWER_PORT` in `example/.env`.
+
+## What it does
+
+- **Lists all cameras** (online/offline) on the landing page with thumbnails.
+- **Click a camera tile** to open a live WebRTC stream in the browser. Toggle main/sub stream quality.
+- **Snapshot button** fetches a current image — cloud thumbnail when available, live WebRTC capture otherwise. The `X-Snapshot-Source` response header tells you which path was used.
+
+## File map
+
+| File | What it is |
+|---|---|
+| [example/viewer.js](../example/viewer.js) | HTTP server (Node http module, no Express). Routes below. |
+| [example/public/viewer.html](../example/public/viewer.html) | Single-page browser app — vanilla JS, no build step. |
+| [example/.env.example](../example/.env.example) | Template for credentials + viewer port. |
+
+## Routes (all under [example/viewer.js](../example/viewer.js))
+
+| Route | Returns |
+|---|---|
+| `GET /` | Serves `viewer.html` |
+| `GET /api/cameras` | `{cameras: [Summary[]]}` from `wyze.getCameraSummaries()` |
+| `GET /api/stream-params?mac=&productModel=&substream=` | Stream credentials from `getCameraWebRTCConnectionInfo` (cache bypassed for fresh URLs) |
+| `GET /api/snapshot?mac=` | `image/jpeg` bytes via `getCameraSnapshotImage`. `X-Snapshot-Source: cloud\|capture` header indicates which path was used. |
+| `GET /api/thumbnail?url=` | Proxies a remote thumbnail image (CORS workaround for cloud URLs) |
+| `GET /api/debug/devices` | Raw camera device JSON — useful for confirming online-state field detection |
+| `GET /api/health` | `{ok: true}` |
+
+## Adapting for your own UI
+
+The HTTP routes are intentionally minimal — read `viewer.js`, copy the route handlers you need, drop them into your own framework. The library calls themselves (`getCameraSummaries`, `getCameraWebRTCConnectionInfo`, `getCameraSnapshotImage`) are the actual interface; the example just wraps them in HTTP.
+
+## Adapting for Homebridge
+
+The same library calls work inside a Homebridge plugin — `getCameraSnapshotImage` for HomeKit snapshot requests, `getCameraWebRTCConnectionInfo` if you wire up an actual WebRTC bridge. No extra dependencies; everything is `package.json`-installable.
+
+## See also
+
+- **[Camera Streaming](Camera-Streaming.md)** — the underlying methods
+- **[Snapshot Capture](Snapshot-Capture.md)** — how the snapshot path works
+- **[Troubleshooting](Troubleshooting.md)** — debugging connection issues

--- a/wiki/Camera-Streaming.md
+++ b/wiki/Camera-Streaming.md
@@ -1,0 +1,129 @@
+# Camera Streaming
+
+How to fetch live WebRTC stream credentials from a Wyze camera and use them in your application.
+
+## Install
+
+```bash
+npm install wyze-api
+```
+
+That's it. The deps `werift` (pure-JS WebRTC), `ws` (WebSocket client), and `ffmpeg-static` (ffmpeg binary, used only by the snapshot capture path) come along automatically. **No system installs needed.**
+
+## Quickstart — getting stream credentials
+
+```js
+const Wyze = require("wyze-api");
+
+const wyze = new Wyze({
+  username: process.env.USERNAME,
+  password: process.env.PASSWORD,
+  keyId: process.env.KEY_ID,
+  apiKey: process.env.API_KEY,
+  persistPath: "./",
+});
+
+await wyze.maybeLogin();
+
+const camera = await wyze.getCameraByName("Front Porch");
+const conn = await wyze.getCameraWebRTCConnectionInfo(camera.mac, camera.product_model);
+
+// `conn` looks like:
+// {
+//   signalingUrl: "wss://m-XXXX.kinesisvideo.us-west-2.amazonaws.com/...",
+//   iceServers: [
+//     { urls: "turn:35-88-...:443", username: "...", credential: "..." },
+//     { urls: "stun:stun.l.google.com:19302" },
+//     ...
+//   ],
+//   authToken: "...",
+//   clientId: "viewer-ccddeeff-1714137600000-a1b2c3d4",
+//   mac: "AA:BB:CC:DD:EE:FF",
+//   model: "WYZE_CAKP2JFUS",
+//   substream: false,
+//   cached: false,
+// }
+```
+
+You hand `signalingUrl` + `iceServers` to a WebRTC client (browser, [werift](https://github.com/shinyoshiaki/werift-webrtc), [go2rtc](https://github.com/AlexxIT/go2rtc)) — this library does **not** stream video itself, only fetches the credentials a video stack needs.
+
+> **Important**: pass the `signalingUrl` to your WebSocket **as-is**. Wyze pre-signs the URL with AWS SigV4; modifying any query parameter (including `X-Amz-ClientId`) will invalidate the signature and AWS will close the connection with code 1006.
+
+## Method reference
+
+### Lookup
+
+| Method | Returns | Notes |
+|---|---|---|
+| `getCameras()` | `Camera[]` | filtered by `product_type === "Camera"` (case-insensitive) |
+| `getOnlineCameras()` | `Camera[]` | only cameras whose `cameraIsOnline` is true |
+| `getOfflineCameras()` | `Camera[]` | inverse of above |
+| `getCamera(mac)` | `Camera \| undefined` | exact MAC match |
+| `getCameraByName(nickname)` | `Camera \| undefined` | nickname match, case-insensitive |
+| `getCameraSummaries()` | `Summary[]` | one summary per camera (see `cameraToSummary`) |
+
+### Pure helpers (sync, take a device object)
+
+| Method | Returns |
+|---|---|
+| `cameraIsOnline(device)` | `boolean` — checks `conn_state` → `device_params.status` → `is_online` in priority order |
+| `cameraGetThumbnail(device)` | first thumbnail URL or `null` |
+| `cameraGetSnapshot(device)` | first thumbnail object `{url, ts, type, ...}` or `null` |
+| `cameraToSummary(device)` | `{mac, productModel, nickname, online, thumbnail}` |
+| `cameraGetSignalStrength(device)` | Wi-Fi signal level or `null` |
+| `cameraGetIp(device)` | local LAN IP or `null` |
+| `cameraGetFirmware(device)` | firmware version string or `null` |
+| `cameraGetTimezone(device)` | timezone name or `null` |
+| `cameraGetLastSeen(device)` | `Date` or `null` |
+
+### Stream credentials
+
+| Method | Notes |
+|---|---|
+| `getCameraWebRTCConnectionInfo(mac, model, [options])` | **Primary entry point.** Bundle: `{signalingUrl, iceServers, authToken, clientId, mac, model, substream, cached}`. ICE servers normalized to `{urls, ...}` for `RTCPeerConnection`. |
+| `getCameraWebRTCConnectionInfoWithReconnect(mac, model, [options], [retryOptions])` | Same, with exponential backoff retry. `retryOptions: {maxAttempts=3, baseDelayMs=2000, onRetry}`. |
+| `cameraGetStreamInfo(mac, model, [options])` | Lower-level — returns the raw API shape `{signaling_url, ice_servers, auth_token, ...}`. |
+| `cameraGetSignalingUrl(mac, model, [options])` | Just the URL string. |
+| `cameraGetIceServers(mac, model, [options])` | Just the ICE list. |
+| `clearCameraStreamCache([mac])` | Clear the in-memory cache (one camera or all). |
+| `cameraStreamWithReconnect(fn, [retryOptions])` | Generic exponential-backoff wrapper for any stream call. |
+
+### `getCameraWebRTCConnectionInfo` options
+
+| Option | Default | Notes |
+|---|---|---|
+| `substream` | `false` | request lower-bitrate sub stream |
+| `includeClientId` | `true` | generate (or accept) a client ID in the result |
+| `clientId` | — | caller-supplied client ID (overrides generation) |
+| `clientIdPrefix` | `"viewer"` | prefix when generating |
+| `noCache` | `false` | bypass the in-memory cache |
+| `cacheTtlMs` | `60_000` | cache TTL when caching is enabled |
+
+## Caching
+
+Connection info is cached per `(mac, model, substream)` for 60 seconds by default. Two consecutive calls for the same camera within that window share one API request:
+
+```js
+const a = await wyze.getCameraWebRTCConnectionInfo(mac, model);
+console.log(a.cached); // false — fresh fetch
+const b = await wyze.getCameraWebRTCConnectionInfo(mac, model);
+console.log(b.cached); // true — served from cache
+```
+
+Pass `noCache: true` to bypass for one call, or `clearCameraStreamCache(mac)` to invalidate.
+
+## Static exports
+
+```js
+const Wyze = require("wyze-api");
+console.log(Wyze.StreamStatus);
+// { OFFLINE: -90, STOPPING: -1, DISABLED: 0, STOPPED: 1, CONNECTING: 2, CONNECTED: 3 }
+```
+
+`StreamStatus` lifecycle constants mirror [docker-wyze-bridge](https://github.com/mrlt8/docker-wyze-bridge)'s stream states for cross-ecosystem compatibility.
+
+## See also
+
+- **[Snapshot Capture](Snapshot-Capture.md)** — fetching JPEG images (cloud or live capture)
+- **[Browser Viewer Example](Browser-Viewer-Example.md)** — runnable end-to-end demo
+- **[Troubleshooting](Troubleshooting.md)** — common errors

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,0 +1,22 @@
+# wyze-api Wiki
+
+Documentation for the camera-related features added in v1.1.10. Other parts of the library are documented in the project [README](../README.md).
+
+## Pages
+
+- **[Camera Streaming](Camera-Streaming.md)** — install, full method reference for camera lookup / WebRTC stream credentials / device-info accessors, code examples
+- **[Snapshot Capture](Snapshot-Capture.md)** — cloud thumbnails + headless WebRTC frame capture (the cloud → live-capture fallback)
+- **[Browser Viewer Example](Browser-Viewer-Example.md)** — running `example/viewer.js` to see your cameras live in a browser
+- **[Troubleshooting](Troubleshooting.md)** — common errors and fixes (codec negotiation, WebSocket 1006, ffmpeg not found, offline cameras, rate limits)
+
+## What this gives you
+
+- **Live WebRTC streaming credentials** for any Wyze camera — signaling URL + ICE servers ready to drop into a `RTCPeerConnection`.
+- **JPEG snapshots** with automatic fallback: try the cloud thumbnail first, capture from the live stream if unavailable.
+- **Camera helpers** — sync accessors for online state, IP, signal strength, firmware, etc., plus async lookups by MAC or nickname.
+- **All in `package.json`** — no system installs. The bundled `ffmpeg-static` provides the ffmpeg binary used for the snapshot capture path.
+
+## Out of scope
+
+- **TUTK protocol** (peer-to-peer direct camera streaming used by [docker-wyze-bridge](https://github.com/mrlt8/docker-wyze-bridge)) — requires native bindings and is a different transport. If you need a long-running bridge with multiple output formats (RTSP, HLS, MP4), use docker-wyze-bridge.
+- **Persistent video relay** — this library hands you stream credentials and one-off frame captures. Continuous video relay is a separate concern; pair this with `go2rtc` or similar if you need an RTSP feed.

--- a/wiki/Snapshot-Capture.md
+++ b/wiki/Snapshot-Capture.md
@@ -1,0 +1,78 @@
+# Snapshot Capture
+
+Two paths exist for getting a JPEG of a Wyze camera:
+
+1. **Cloud thumbnail** — Wyze stores periodic snapshots; the device list includes the URL. Free, instant, but the cloud doesn't always have one (newly online camera, low-traffic camera, sometimes stale).
+2. **Live WebRTC capture** — negotiate a one-shot WebRTC session, grab a single H.264 frame, decode to JPEG via ffmpeg, tear down. Always works for online cameras, but takes 3–5 seconds and requires more resources.
+
+`getCameraSnapshotImage(mac, options)` does the right thing automatically: tries cloud, falls back to capture.
+
+## What's needed
+
+Just `npm install`. The `ffmpeg-static` npm package ships the ffmpeg binary for your platform — no system install. Supported platforms: macOS x64/arm64, Linux x64/arm/arm64, Windows x64.
+
+## Methods
+
+| Method | Returns | Notes |
+|---|---|---|
+| `getCameraSnapshot(mac)` | `{url, ts, ...} \| null` | cloud thumbnail metadata only |
+| `getCameraSnapshotUrl(mac)` | `string \| null` | just the cloud URL |
+| `cameraCaptureSnapshot(mac, model, [options])` | `Buffer` (JPEG) | live WebRTC capture, no cloud check |
+| `getCameraSnapshotImage(mac, [options])` | `{buffer, source}` | **Primary**: tries cloud, falls back to capture |
+
+### `getCameraSnapshotImage(mac, options)`
+
+```js
+const { buffer, source } = await wyze.getCameraSnapshotImage(mac);
+// source === "cloud" — got it from a cached cloud thumbnail
+// source === "capture" — fell back to a live WebRTC capture
+
+await fs.promises.writeFile(`${mac}.jpg`, buffer);
+```
+
+Options:
+
+| Option | Default | Notes |
+|---|---|---|
+| `skipCloud` | `false` | go straight to live capture |
+| `timeoutMs` | `20_000` | overall timeout for the capture path |
+| `noCache` | `false` | bypass the per-mac capture cache |
+| `cacheTtlMs` | `10_000` | capture-cache TTL |
+
+### `cameraCaptureSnapshot(mac, model, options)` directly
+
+```js
+const buffer = await wyze.cameraCaptureSnapshot(mac, model);
+// Buffer of JPEG bytes
+```
+
+The capture is cached per-mac for 10 seconds — rapid repeat calls share one capture. Useful when multiple consumers (e.g., several HomeKit accessories) ask for the same camera within seconds.
+
+## How the live capture works
+
+```
+┌──────────────┐      ┌─────────┐      ┌──────────────┐      ┌────────┐
+│ Wyze REST    │ ──>  │ werift  │ ──>  │ UDP socket   │ ──>  │ ffmpeg │ ──> JPEG
+│ /get-streams │      │ (WebRTC │      │ (RTP relay)  │      │ (H.264 │
+│              │      │  recv)  │      │              │      │  → JPG)│
+└──────────────┘      └─────────┘      └──────────────┘      └────────┘
+```
+
+1. Fetch fresh stream credentials via `getCameraWebRTCConnectionInfo` (no cache; we want a fresh signed URL).
+2. werift opens a `RTCPeerConnection` configured for **H.264 baseline 3.1** (the profile every Wyze cam supports — werift's default codec list excludes H.264 explicitly, so we pin it).
+3. Open a WebSocket to the Kinesis Video signaling URL, exchange SDP offer/answer + ICE candidates using Wyze's envelope format (same one `viewer.html` uses).
+4. Each H.264 RTP packet werift receives is forwarded over UDP to a local port that ffmpeg is listening on (driven by a temp SDP file).
+5. ffmpeg decodes one frame, encodes to JPEG, writes to stdout. We capture stdout, return the buffer.
+6. Tear down: WebSocket close, peer connection close, UDP socket close, ffmpeg kill, temp file unlink.
+
+Code: [src/cameraStreamCapture.js](../src/cameraStreamCapture.js).
+
+## When to use which
+
+- **HomeKit / Home Assistant snapshot** — `getCameraSnapshotImage(mac)`. Fast when cloud has one, robust fallback when not.
+- **You always want the live frame** — `cameraCaptureSnapshot(mac, model)` or `getCameraSnapshotImage(mac, {skipCloud: true})`.
+- **You only want metadata** (URL, timestamp) without downloading bytes — `getCameraSnapshot(mac)`.
+
+## Troubleshooting
+
+See **[Troubleshooting](Troubleshooting.md)** for snapshot-specific errors (ffmpeg not found, codec negotiation, timeouts).

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -1,0 +1,99 @@
+# Troubleshooting
+
+Camera scope only. Other library issues are covered in the project [README](../README.md).
+
+## All cameras show as offline
+
+The lib's `cameraIsOnline` checks three fields in priority order: `device.conn_state` → `device.device_params.status` → `device.is_online`. If your Wyze account returns online state in a field this lib doesn't know about, fix it by:
+
+1. Hitting `GET http://localhost:3030/api/debug/devices` (with the [browser viewer](Browser-Viewer-Example.md) running) to dump raw device JSON.
+2. Look at one camera you know is online and find which field is set.
+3. Open an issue with the field name + value.
+
+## WebSocket close 1006 immediately after connect
+
+You're modifying the signed signaling URL. Wyze pre-signs with AWS SigV4, and changing any query parameter (especially `X-Amz-ClientId`) invalidates the signature.
+
+**Fix:** pass `signalingUrl` to `new WebSocket(...)` exactly as returned. Don't append, don't replace, don't decode further. The lib does NOT modify the URL by default — make sure your code isn't doing it either.
+
+## "negotiate codecs failed" during snapshot capture
+
+werift's default codec list doesn't include H.264, but Wyze cameras only stream H.264. The lib pins H.264 baseline 3.1 (`profile-level-id=42001f`) explicitly inside `cameraStreamCapture.js`. If you see this error, you're either:
+
+- On a stale install — re-run `npm install` and check that `werift` resolves to ≥0.20.
+- Using `cameraGetStreamInfo` directly with your own `RTCPeerConnection` setup (browser code) — make sure your transceiver advertises H.264. The browser does this automatically; werift in Node does not.
+
+## "ffmpeg binary not found"
+
+`ffmpeg-static` failed to download the binary during `npm install`. This usually means:
+
+- **Unsupported platform** (e.g., uncommon ARM variant). Install ffmpeg via your OS package manager (`brew install ffmpeg`, `apt install ffmpeg`) and the lib will fall back to system `ffmpeg`.
+- **Network issue during install** — try `npm install --force` or delete `node_modules` and reinstall.
+
+The error message includes the exact path the lib tried.
+
+## "Camera is offline" thrown from `cameraGetStreamInfo`
+
+Two distinct failure modes:
+
+1. **Top-level `code === "3019"`** — the Wyze API itself reports the camera as offline. This usually means the camera lost its Wi-Fi connection or is unplugged. The Wyze app will show the same.
+2. **`iot-device::iot-state !== 1` in the response** — the camera responded but isn't ready to stream. Power-cycling the camera (or toggling its switch in the Wyze app) usually fixes this.
+
+## Snapshot capture times out at 20 seconds
+
+The most common cause is the camera not sending a keyframe quickly enough. werift waits for the first decodable frame; if the camera's keyframe interval is large or the connection is bad, this can exceed 20s.
+
+**Try:**
+
+- Increase the timeout: `wyze.cameraCaptureSnapshot(mac, model, {timeoutMs: 40_000})`.
+- Use `substream: true` for a lower-bitrate stream that often delivers a keyframe faster.
+- Verify the camera streams successfully in the [browser viewer](Browser-Viewer-Example.md) — if the browser can't stream it either, it's a camera-side problem.
+
+## Access token / "Wyze access token error"
+
+The lib will detect a `code === 2001` response, automatically clear and refresh the token, then throw with a "retry the call" message. **Catch the error and retry once** — the next call will use the fresh token:
+
+```js
+async function withRetry(fn) {
+  try { return await fn(); }
+  catch (err) {
+    if (/access token error/i.test(err.message)) return fn();
+    throw err;
+  }
+}
+const conn = await withRetry(() => wyze.getCameraWebRTCConnectionInfo(mac, model));
+```
+
+Or use the built-in retry wrapper:
+
+```js
+const conn = await wyze.getCameraWebRTCConnectionInfoWithReconnect(mac, model);
+```
+
+## Rate limiting
+
+`cameraGetStreamInfo` reads the `X-RateLimit-Remaining` header on every response. If it's below 7, the lib auto-sleeps until `X-RateLimit-Reset-By`. Below that, it throws "Wyze API rate limited (...)" — pause your loops and back off.
+
+The 60-second cache on `getCameraWebRTCConnectionInfo` exists specifically to keep your rate-limit budget healthy under reconnect storms; don't bypass it (`noCache: true`) without a reason.
+
+## Stream works for a few seconds then drops
+
+Almost always an ICE/network issue, not the lib:
+
+- TURN credentials in the response are short-lived. If you stash them and use them later, they expire. Always fetch fresh credentials immediately before opening the connection.
+- Behind double NAT / strict firewalls, UDP-based ICE can fail. The lib returns the TURN servers Wyze provides, which use TCP-relay-on-443 as a fallback — that's usually the path that works on restrictive networks.
+
+## Diagnostic logging
+
+Pass `apiLogEnabled: true` in the constructor:
+
+```js
+const wyze = new Wyze({ ..., apiLogEnabled: true });
+```
+
+Stream-related calls will log:
+- `[capture] track received kind=video codec=H264`
+- `[capture] applied SDP_ANSWER`
+- `[capture] captured 28341 bytes`
+
+Plus the regular API request/response bodies for debugging the Wyze REST flow.


### PR DESCRIPTION
## Summary

- Ports camera WebRTC stream API from [wyzeapy#230](https://github.com/SecKatie/wyzeapy/pull/230) and adds a production surface around it: lookup helpers, device-info accessors, connection bundling with caching/retry, and a headless JPEG snapshot path that auto-falls-back from cloud thumbnails to live WebRTC frame capture.
- All deps installable via `package.json` — `werift` (pure-JS WebRTC), `ws` (WebSocket), `ffmpeg-static` (bundled ffmpeg). No system installs, works inside Homebridge.
- Includes browser viewer example, 62 unit tests (Node's built-in test runner — no new test framework dep), 5-page wiki, and a workflow that syncs `wiki/` to the GitHub Wiki.

## What's new

**Camera scope methods** (all on `WyzeAPI.prototype`)

- `getCameraWebRTCConnectionInfo(mac, model, options)` — primary entry point. Returns `{signalingUrl, iceServers, authToken, clientId, mac, model, substream, cached}`. ICE servers normalized to the `{urls, ...}` shape `RTCPeerConnection` expects; signaling URL returned untouched (modifying breaks AWS SigV4 signature → WS 1006). 60s cache per `(mac, model, substream)`.
- `getCameraWebRTCConnectionInfoWithReconnect` / `cameraStreamWithReconnect` — exponential-backoff retry wrappers.
- `cameraGetStreamInfo` / `cameraGetSignalingUrl` / `cameraGetIceServers` — lower-level. Wired into the existing `_checkRateLimit` (`X-RateLimit-Remaining`) and `_isAccessTokenError` (code `2001`) handlers — bypasses no longer.
- `cameraCaptureSnapshot(mac, model)` + `getCameraSnapshotImage(mac, options)` — headless WebRTC capture. werift negotiates H.264 baseline 3.1 recvonly, RTP packets relay over UDP into ffmpeg-static, JPEG out. 10s per-mac capture cache. Returns `{buffer, source: "cloud" | "capture"}` from `getCameraSnapshotImage`.
- Lookups: `getCameras`, `getOnlineCameras`, `getOfflineCameras`, `getCamera(mac)`, `getCameraByName(nickname)`, `getCameraSnapshot(mac)`, `getCameraSnapshotUrl(mac)`, `getCameraSummaries`.
- Pure sync helpers: `cameraIsOnline` (3-field fallback: `conn_state` → `device_params.status` → `is_online`), `cameraToSummary`, `cameraGetThumbnail/Snapshot`, plus accessors for signal strength, IP, firmware, timezone, last-seen.
- `WyzeAPI.StreamStatus` constants mirroring docker-wyze-bridge.

**Example**: `example/viewer.js` HTTP server + `example/public/viewer.html` browser app — full demo of every camera helper end-to-end.

**Tests**: 62 passing under `tests/` via `npm test` (uses Node's built-in `node --test`, no new framework). Includes a regression test pinning the no-URL-mutation behavior that was causing WS 1006.

**Wiki + automation**: 5 pages under `wiki/` (Home, Camera-Streaming, Snapshot-Capture, Browser-Viewer-Example, Troubleshooting). `.github/workflows/wiki-sync.yml` mirrors them to the GitHub Wiki on push to main.

## Why

Camera streaming is the most-requested capability for downstream consumers (homebridge-wyze-smart-home, custom scripts). Previously you had to call out to docker-wyze-bridge or roll your own. Now `wyze-api` returns ready-to-use WebRTC credentials and JPEG snapshots in a few lines of code.

## Reviewer notes

- **No system dependencies.** ffmpeg-static covers macOS x64/arm64, Linux x64/arm/arm64, Windows x64. Falls back to system `ffmpeg` if the bundled binary doesn't resolve.
- **Wiki action needs one-time setup** — GitHub creates the wiki repo only after the first manual page is added. See the message at the bottom of the wiki sync workflow file.
- **`example/.env.example` is the only env-related file in the diff** — it's a template with placeholder values, not real creds. Confirmed via grep before committing.
- **`package-lock.json` was updated by `npm install`** when adding the three new deps. That's the intended source of changes there, not manual edits.
- **Version bumped to 1.1.10**, CHANGELOG entry added.
- **Out of scope**: TUTK protocol streaming (would require native bindings), persistent video relay (use go2rtc/docker-wyze-bridge for that). Wiki has a brief note on this.

## Test plan

- [ ] `npm test` passes (62/62 currently)
- [ ] `cd example && npm install && npm run viewer` lists cameras at http://localhost:3030
- [ ] Click a camera tile → live WebRTC stream plays
- [ ] Click snapshot button → JPEG appears (test both online camera with cloud thumbnail and one without to exercise both source paths)
- [ ] Try `wyze.getCameraSnapshotImage(mac, {skipCloud: true})` from a script to force the live capture path
- [ ] Verify `npm install` works on a clean checkout (deps resolve, ffmpeg-static binary downloads)

🤖 Generated with [Claude Code](https://claude.com/claude-code)