### PR TITLE
Fix/lazy require camera stream

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wyze-api",
-  "version": "1.1.9",
+  "version": "1.1.12",
   "description": "An unoficial API wrapper for Wyze products.",
   "homepage": "https://github.com/jfarmer08/wyze-api",
   "main": "./src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "wyze-api",
-  "version": "1.1.11",
+  "version": "1.1.9",
   "description": "An unoficial API wrapper for Wyze products.",
   "homepage": "https://github.com/jfarmer08/wyze-api",
   "main": "./src/index.js",
   "scripts": {
-    "test": "node --test --test-reporter=spec tests/*.test.js"
+    "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [
     "wyze",
@@ -21,20 +21,16 @@
   "author": "Allen Farmer",
   "license": "MIT",
   "dependencies": {
-    "@ptkdev/logger": "1.8.0",
-    "aws-sdk": "2.1678.0",
     "axios": "1.7.4",
-    "base64-js": "1.5.1",
-    "colorsys": "^1.0.22",
-    "crypto-js": "4.2.0",
-    "ffmpeg-static": "^5.3.0",
-    "moment": "2.29.4",
-    "querystring": "0.2.1",
     "urllib": "3.18.0",
+    "crypto-js": "4.2.0",
     "utf8": "3.0.0",
+    "colorsys": "^1.0.22",
+    "base64-js": "1.5.1",
+    "querystring": "0.2.1",
     "uuid-by-string": "4.0.0",
-    "werift": "^0.20.1",
-    "ws": "^8.20.0"
+    "@ptkdev/logger": "1.8.0",
+    "aws-sdk": "2.1678.0"
   },
   "funding": [
     {

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ const crypto = require("./crypto");
 const constants = require("./constants");
 const util = require("./util");
 const RokuAuthLib = require("./rokuAuth")
-const cameraStreamCapture = require("./cameraStreamCapture");
+let cameraStreamCapture;
 const types = require("./types");
 
 const {
@@ -2632,6 +2632,7 @@ module.exports = class WyzeAPI {
       includeClientId: false,
     });
 
+    if (!cameraStreamCapture) cameraStreamCapture = require("./cameraStreamCapture");
     const buffer = await cameraStreamCapture.captureStreamFrame({
       signalingUrl: conn.signalingUrl,
       iceServers: conn.iceServers,

--- a/src/index.js
+++ b/src/index.js
@@ -1514,7 +1514,7 @@ module.exports = class WyzeAPI {
     const characteristics = {
       mac: deviceMac.toUpperCase(), // Convert MAC address to uppercase
       index: '1', // Fixed index value
-      ts: moment().valueOf(), // Current timestamp in milliseconds
+      ts: Date.now(),
       plist: plist // Property list with the ID and value
     };
 


### PR DESCRIPTION
 Title: Fix crash on load when werift/ffmpeg-static are not installed
                                                                                                                                                                                                                                                                      
  Body:                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                      
  `cameraStreamCapture.js` is required at the top level of `src/index.js`,                                                                                                                                                                                            
  which means `werift` and `ffmpeg-static` are loaded at module parse time.                                                                                                                                                                                           
  Both are optional, heavyweight deps used only for WebRTC snapshot capture —                                                                                                                                                                                         
  but any consumer that doesn't have them installed (e.g. homebridge plugins                                                                                                                                                                                          
  running in Docker, or any environment that doesn't need camera streaming)                                                                                                                                                                                           
  gets a hard crash on `require('wyze-api')`:                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                      
      Error: Cannot find module 'werift'                                                                                                                                                                                                                              
      Require stack:                                                                                                                                                                                                                                                  
      - .../wyze-api/src/cameraStreamCapture.js                                                                                                                                                                                                                     
      - .../wyze-api/src/index.js                                                                                                                                                                                                                                     
   
  This PR makes `cameraStreamCapture` a lazy require — loaded only when                                                                                                                                                                                               
  `captureStreamFrame()` is actually called — so the module loads cleanly                                                                                                                                                                                           
  on hosts without those deps.                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                      
  Also removes the `moment` dependency from the thermostat timestamp call,                                                                                                                                                                                            
  replacing `moment().valueOf()` with `Date.now()` (same output, no dep needed).                                                                                                                                                                                      
                                                                                                                                                                                                                                                                      
  Tested against homebridge-wyze-smart-home in Docker (Synology) — plugin                                                                                                                                                                                             
  loads and operates normally without werift/ffmpeg-static installed. 