### PR TITLE
Bug fixes + lazy-load camera streaming + remove moment dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wyze-api",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "description": "An unoficial API wrapper for Wyze products.",
   "homepage": "https://github.com/jfarmer08/wyze-api",
   "main": "./src/index.js",
@@ -28,7 +28,6 @@
     "colorsys": "^1.0.22",
     "crypto-js": "4.2.0",
     "ffmpeg-static": "^5.3.0",
-    "moment": "2.29.4",
     "querystring": "0.2.1",
     "urllib": "3.18.0",
     "utf8": "3.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,6 @@ const crypto = require("./crypto");
 const constants = require("./constants");
 const util = require("./util");
 const RokuAuthLib = require("./rokuAuth")
-const cameraStreamCapture = require("./cameraStreamCapture");
 const types = require("./types");
 
 const {
@@ -1514,7 +1513,7 @@ module.exports = class WyzeAPI {
     const characteristics = {
       mac: deviceMac.toUpperCase(), // Convert MAC address to uppercase
       index: '1', // Fixed index value
-      ts: moment().valueOf(), // Current timestamp in milliseconds
+      ts: Date.now(), // Current timestamp in milliseconds
       plist: plist // Property list with the ID and value
     };
 
@@ -1556,7 +1555,7 @@ module.exports = class WyzeAPI {
 
         // Handle fallback to cloud
         console.log(`Attempting to fallback to cloud for device ${deviceMac}.`);
-        await runActionList(deviceMac, deviceModel, propertyId, propertyValue, actionKey);
+        await this.runActionList(deviceMac, deviceModel, propertyId, propertyValue, actionKey);
       } else {
         // Log other types of errors
         console.error(`Error occurred while sending command to device ${deviceMac}:`, error);
@@ -1568,7 +1567,7 @@ module.exports = class WyzeAPI {
     const rokuAuth = new RokuAuthLib(this.username, this.password);
     const token = await rokuAuth.getTokenWithUsernamePassword(this.username, this.password);
 
-    print(token)
+    this.log.info(token);
   }
 
   // Wyze Robot Vacuum (Venus service) — JA_RO2.
@@ -2632,6 +2631,7 @@ module.exports = class WyzeAPI {
       includeClientId: false,
     });
 
+    const cameraStreamCapture = require("./cameraStreamCapture");
     const buffer = await cameraStreamCapture.captureStreamFrame({
       signalingUrl: conn.signalingUrl,
       iceServers: conn.iceServers,


### PR DESCRIPTION
- Fix runtime crashes: replace moment().valueOf() with Date.now()
- Fix missing 'this.' context on runActionList() fallback call
- Replace global print(token) with this.log.info(token)
- Lazy-load cameraStreamCapture to avoid crash when werift/ffmpeg-static not installed
- Remove unused moment dependency from package.json

@jfarmer08 Please update npm, and then ill have a bigger update for [homebridge-wyze-smart-home](https://github.com/jfarmer08/homebridge-wyze-smart-home)