### PR TITLE
Fix Ford API signing for original Wyze Lock (v1.1.14)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wyze-api",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "description": "An unoficial API wrapper for Wyze products.",
   "homepage": "https://github.com/jfarmer08/wyze-api",
   "main": "./src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wyze-api",
   "version": "1.1.14",
-  "description": "An unoficial API wrapper for Wyze products.",
+  "description": "An unofficial API wrapper for Wyze products.",
   "homepage": "https://github.com/jfarmer08/wyze-api",
   "main": "./src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wyze-api",
-  "version": "1.1.13",
+  "version": "1.1.14",
   "description": "An unoficial API wrapper for Wyze products.",
   "homepage": "https://github.com/jfarmer08/wyze-api",
   "main": "./src/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -781,9 +781,6 @@ module.exports = class WyzeAPI {
       with_keypad: "1",
     };
     try {
-      let config = {
-        params: payload,
-      };
       payload = payloadFactory.fordCreatePayload(
         this.access_token,
         payload,
@@ -791,6 +788,7 @@ module.exports = class WyzeAPI {
         "get"
       );
 
+      const config = { params: payload };
       const url = "https://yd-saas-toc.wyzecam.com/openapi/lock/v1/info";
       const result = await axios.get(url, config);
       if (this.apiLogEnabled) {

--- a/src/payloadFactory.js
+++ b/src/payloadFactory.js
@@ -2,13 +2,21 @@ const constants = require("./constants");
 const crypto = require("./crypto");
 
 function fordCreatePayload(access_token, payload, url_path, request_method) {
-  return {
+  // GET uses access_token (snake_case); POST uses accessToken (camelCase).
+  // Sending the wrong field name returns PARAM_SIGN_INVALID even when the
+  // signature is otherwise correct (verified against shauntarves/wyze-sdk).
+  const method = String(request_method).toLowerCase();
+  const tokenField = method === "get" ? "access_token" : "accessToken";
+  const augmented = {
     ...payload,
-    accessToken: access_token,
+    [tokenField]: access_token,
     key: constants.fordAppKey,
     timestamp: Date.now().toString(),
-    sign: crypto.fordCreateSignature(url_path, request_method, payload),
   };
+  // Signature must be computed over the augmented payload (all fields
+  // including token/key/timestamp), not the original payload alone.
+  augmented.sign = crypto.fordCreateSignature(url_path, method, augmented);
+  return augmented;
 }
 
 function oliveCreateGetPayload(device_mac, keys) {


### PR DESCRIPTION
## Summary

Fixes #300 in homebridge-wyze-smart-home: original Wyze Lock (YD.LO1) failing with PARAM_SIGN_INVALID on ControlLock and PARAM_TIMESTAMP_INVALID on GetLockInfo.

**Root cause — two bugs in `fordCreatePayload`:**

- `getLockInfo` (GET) was assigning `config.params` before calling `fordCreatePayload`, so the request was sent with the original unsigned params — no `key`, `timestamp`, or `sign`. Fixed by moving `config` assignment after the payload is signed.
- The signature was computed over the original payload only (`uuid`/`action`), but Wyze's server now validates the signature over the **full augmented payload** (including `accessToken`/`key`/`timestamp`). Fixed by building the augmented object first, then signing it.
- GET requests must send `access_token` (snake_case); POST requests must send `accessToken` (camelCase). Wrong field name returns PARAM_SIGN_INVALID even with a valid signature (verified against shauntarves/wyze-sdk).

**Also:** fixed long-standing typo in `package.json` description (`unoficial` → `unofficial`).

## Test plan
- [ ] Original Wyze Lock (YD.LO1) lock/unlock from HomeKit succeeds
- [ ] GetLockInfo no longer returns 17001 PARAM_TIMESTAMP_INVALID
- [ ] ControlLock no longer returns 14008 PARAM_SIGN_INVALID
- [ ] Lock Bolt V2 (DX_LB2) unaffected (uses IoT3, not Ford API)

🤖 Generated with [Claude Code](https://claude.com/claude-code)